### PR TITLE
[Feat] 멤버 조회 임시 서비스 메서드 구현

### DIFF
--- a/src/main/java/sws/songpin/entity/member/domain/Member.java
+++ b/src/main/java/sws/songpin/entity/member/domain/Member.java
@@ -40,8 +40,8 @@ public class Member extends BaseTimeEntity {
     @NotBlank
     private String handle;
 
-    @Column(name = "profile_image")
-    private String profileImage;
+    @Column(name = "profile_img")
+    private ProfileImg profileImg;
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
@@ -54,13 +54,13 @@ public class Member extends BaseTimeEntity {
     private List<Pin> pins;
 
     @Builder
-    public Member(Long memberId, String email, String password, String nickname, String handle, String profileImage, Status status, boolean isNewAlarm) {
+    public Member(Long memberId, String email, String password, String nickname, String handle, ProfileImg profileImg, Status status, boolean isNewAlarm) {
         this.memberId = memberId;
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.handle= handle;
-        this.profileImage = profileImage;
+        this.profileImg = profileImg;
         this.status = status;
         this.isNewAlarm = isNewAlarm;
         this.pins = new ArrayList<>();

--- a/src/main/java/sws/songpin/entity/member/domain/Member.java
+++ b/src/main/java/sws/songpin/entity/member/domain/Member.java
@@ -40,6 +40,7 @@ public class Member extends BaseTimeEntity {
     private String handle;
 
     @Column(name = "profile_img")
+    @Enumerated(EnumType.STRING)
     private ProfileImg profileImg;
 
     @Column(name = "status", nullable = false)

--- a/src/main/java/sws/songpin/entity/member/domain/Member.java
+++ b/src/main/java/sws/songpin/entity/member/domain/Member.java
@@ -29,7 +29,6 @@ public class Member extends BaseTimeEntity {
 
     @Column(name = "password", nullable = false)
     @NotBlank
-    @Size(min = 8, max = 20)
     private String password;
 
     @Column(name = "nickname", nullable = false)

--- a/src/main/java/sws/songpin/entity/member/domain/ProfileImg.java
+++ b/src/main/java/sws/songpin/entity/member/domain/ProfileImg.java
@@ -1,0 +1,20 @@
+package sws.songpin.entity.member.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum ProfileImg {
+    ROCK, // 락&메탈
+    BALLAD, // 발라드
+    POP, // 팝
+    JAZZ, // 재즈
+    HIPHOP, // 힙합
+    LOFI, // 로파이
+    DANCE, // 댄스
+    EXTRA // 나머지
+    ;
+
+    @JsonCreator
+    public static ProfileImg from(String s) {
+        return ProfileImg.valueOf(s.toUpperCase());
+    }
+}

--- a/src/main/java/sws/songpin/entity/member/repository/MemberRepository.java
+++ b/src/main/java/sws/songpin/entity/member/repository/MemberRepository.java
@@ -1,4 +1,7 @@
 package sws.songpin.entity.member.repository;
 
-public class MemberRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import sws.songpin.entity.member.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member,Long> {
 }

--- a/src/main/java/sws/songpin/entity/member/service/MemberService.java
+++ b/src/main/java/sws/songpin/entity/member/service/MemberService.java
@@ -1,4 +1,22 @@
 package sws.songpin.entity.member.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sws.songpin.entity.member.domain.Member;
+import sws.songpin.entity.member.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
 public class MemberService {
+    private final MemberRepository memberRepository;
+
+    //개발 진행을 위한 임시 메서드
+    public Member getCurrentMember(){
+        return memberRepository.findById((long)1).get();
+    }
+    public Member getMemberById(Long memberId){
+        return memberRepository.findById(memberId).get();
+    }
+
+
 }

--- a/src/test/java/sws/songpin/entity/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/sws/songpin/entity/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,38 @@
+package sws.songpin.entity.member.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import sws.songpin.entity.member.domain.Member;
+import sws.songpin.entity.member.domain.ProfileImg;
+import sws.songpin.entity.member.domain.Status;
+
+import java.time.LocalDate;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    public void testInsertMember(){
+        IntStream.rangeClosed(1,10).forEach(i-> {
+            Member member = Member.builder()
+                    .memberId((long) i)
+                    .email("test"+i+"@test.com")
+                    .nickname("testnickname"+i)
+                    .password("testpw"+i)
+                    .handle("testhandle"+i)
+                    .profileImg(ProfileImg.DANCE)
+                    .status(Status.ACTIVE)
+                    .isNewAlarm(false)
+                    .build();
+            memberRepository.save(member);
+        });
+    }
+
+}


### PR DESCRIPTION
# 구현 기능
  - 멤버 조회 임시 서비스 메서드 구현
  - 멤버 생성 테스트 코드 작성 
  - 멤버 엔티티 수정: profileImage → profileImg 필드명 변경, String → ENUM 타입 변경
  - 멤버 엔티티 수정: password 의 @Size 어노테이션 삭제
  - (+) 멤버 엔티티 수정: @Enumerated 어노테이션 추가

# Resolve
- #9 