### PR TITLE
[Feat] enum들 INVALID_ENUM_VALUE 예외 처리 추가, SortBy 추가

### DIFF
--- a/src/main/java/sws/songpin/domain/genre/entity/GenreName.java
+++ b/src/main/java/sws/songpin/domain/genre/entity/GenreName.java
@@ -1,6 +1,8 @@
 package sws.songpin.domain.genre.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import sws.songpin.global.exception.CustomException;
+import sws.songpin.global.exception.ErrorCode;
 
 public enum GenreName {
     POP, // 팝
@@ -15,7 +17,11 @@ public enum GenreName {
 
     // ex. JSON 데이터 "POP"라는 문자열 -> GenreName.POP으로 변환
     @JsonCreator
-    public static GenreName from(String s) {
-        return GenreName.valueOf(s.toUpperCase());
+    public static GenreName from2(String s) {
+        try {
+            return GenreName.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
     }
 }

--- a/src/main/java/sws/songpin/domain/member/entity/Member.java
+++ b/src/main/java/sws/songpin/domain/member/entity/Member.java
@@ -28,7 +28,7 @@ public class Member extends BaseTimeEntity {
     @NotBlank
     private String email;
 
-    @Column(name = "password", length = 20)
+    @Column(name = "password")
     @NotNull
     @NotBlank
     private String password;

--- a/src/main/java/sws/songpin/domain/member/entity/ProfileImg.java
+++ b/src/main/java/sws/songpin/domain/member/entity/ProfileImg.java
@@ -1,6 +1,8 @@
 package sws.songpin.domain.member.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import sws.songpin.global.exception.CustomException;
+import sws.songpin.global.exception.ErrorCode;
 
 public enum ProfileImg {
     POP, // 팝
@@ -15,6 +17,10 @@ public enum ProfileImg {
 
     @JsonCreator
     public static ProfileImg from(String s) {
-        return ProfileImg.valueOf(s.toUpperCase());
+        try {
+            return ProfileImg.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
     }
 }

--- a/src/main/java/sws/songpin/domain/model/SortBy.java
+++ b/src/main/java/sws/songpin/domain/model/SortBy.java
@@ -1,18 +1,19 @@
-package sws.songpin.domain.member.entity;
+package sws.songpin.domain.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import sws.songpin.global.exception.CustomException;
 import sws.songpin.global.exception.ErrorCode;
 
-public enum Status {
-    ACTIVE,
-    DELETED
+public enum SortBy {
+    ACCURACY,
+    COUNT,
+    NEWEST
     ;
 
     @JsonCreator
-    public static Status from(String s) {
+    public static SortBy from(String s) {
         try {
-            return Status.valueOf(s.toUpperCase());
+            return SortBy.valueOf(s.toUpperCase());
         } catch (IllegalArgumentException e) {
             throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
         }

--- a/src/main/java/sws/songpin/domain/pin/domain/Visibility.java
+++ b/src/main/java/sws/songpin/domain/pin/domain/Visibility.java
@@ -1,6 +1,8 @@
 package sws.songpin.domain.pin.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import sws.songpin.global.exception.CustomException;
+import sws.songpin.global.exception.ErrorCode;
 
 public enum Visibility {
     PUBLIC,
@@ -9,6 +11,10 @@ public enum Visibility {
 
     @JsonCreator
     public static Visibility from(String s) {
-        return Visibility.valueOf(s.toUpperCase());
+        try {
+            return Visibility.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
     }
 }


### PR DESCRIPTION
# 구현 기능
  - 검색 기능 시 사용하는 enum인 `SortBy`를 추가했습니다. 
    - 기존 api 명세 시 작성했던 단어가 너무 길어서 `ACCURACY, COUNT, NEWEST`으로 변경했습니다.
    - 여러 도메인에서 사용되므로 어디에 둘까 하다가 `/domain/model/` 디렉터리를 만들어 그 하위로 위치시켰습니다. 추후 Visibility도 model 하위로 옮기면 좋을 것 같습니다!
  - enum들(`GenreName`, `ProfileImg`, `Status`, `Visibility`, `SortBy`)에 들어오면 안 되는 값이 들어와 `IllegalArgumentException`가 던져지는 경우를 try-catch로 잡아 `CustomException(ErrorCode.INVALID_ENUM_VALUE)`을 던지도록 내부에서 예외 처리 코드를 추가하였습니다.

# Resolve
  - #7 
