### PR TITLE
[Feat] 로그인 API 및 JWT 인증 필터 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5' //jjwt
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5', 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis' //redis
+	implementation 'org.springframework.boot:spring-boot-starter-cache' //캐시
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5', 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis' //redis
 	implementation 'org.springframework.boot:spring-boot-starter-cache' //캐시
+	implementation 'org.json:json:20231013' //JsonObject 사용 관련
 }
 
 tasks.named('test') {

--- a/src/main/java/sws/songpin/domain/member/controller/AuthController.java
+++ b/src/main/java/sws/songpin/domain/member/controller/AuthController.java
@@ -13,24 +13,25 @@ import org.springframework.web.bind.annotation.RestController;
 import sws.songpin.domain.member.dto.request.LoginRequestDto;
 import sws.songpin.domain.member.dto.request.SignUpRequestDto;
 import sws.songpin.domain.member.dto.response.LoginResponseDto;
+import sws.songpin.domain.member.service.AuthService;
 import sws.songpin.domain.member.service.MemberService;
 
 @RestController
 @RequiredArgsConstructor
-public class LoginController {
-    private final MemberService memberService;
+public class AuthController {
+    private final AuthService authService;
 
     @Operation(summary = "회원가입", description = "회원 가입을 통해 유저 생성")
     @PostMapping("/signup")
     public ResponseEntity<Object> signUp(@Valid @RequestBody SignUpRequestDto requestDto){
-        memberService.signUp(requestDto);
+        authService.signUp(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @Operation(summary = "로그인", description = "로그인 결과를 반환합니다.")
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto){
-        LoginResponseDto responseDto = memberService.login(requestDto);
+        LoginResponseDto responseDto = authService.login(requestDto);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/sws/songpin/domain/member/controller/LoginController.java
+++ b/src/main/java/sws/songpin/domain/member/controller/LoginController.java
@@ -5,10 +5,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import sws.songpin.domain.member.dto.request.LoginRequestDto;
 import sws.songpin.domain.member.dto.request.SignUpRequestDto;
+import sws.songpin.domain.member.dto.response.LoginResponseDto;
 import sws.songpin.domain.member.service.MemberService;
 
 @RestController
@@ -21,6 +25,19 @@ public class LoginController {
     public ResponseEntity<Object> signUp(@Valid @RequestBody SignUpRequestDto requestDto){
         memberService.signUp(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "로그인", description = "로그인 결과를 반환합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto){
+        LoginResponseDto responseDto = memberService.login(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @Operation(summary = "토큰 검증 테스트")
+    @GetMapping("/authTest")
+    public String test(Authentication authentication){
+        return authentication.getName();
     }
 
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/LoginRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/LoginRequestDto.java
@@ -1,0 +1,12 @@
+package sws.songpin.domain.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequestDto(
+        @Email
+        @NotBlank
+        String email,
+        @NotBlank
+        String password
+) { }

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -10,7 +10,7 @@ public record SignUpRequestDto(
         @Size(max = 50, message = "INVALID_INPUT_LENGTH-이메일은 50자 이내여야 합니다.")
         String email,
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자 조합만 허용됩니다.")
-        @Size(max = 10, message = "INVALID_INPUT_LENGTH-닉네임은 10자 이내여야 합니다.")
+        @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         String nickname,
         @Size(max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 20자 이내여야 합니다.")
         String password,

--- a/src/main/java/sws/songpin/domain/member/dto/response/LoginResponseDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/response/LoginResponseDto.java
@@ -2,5 +2,5 @@ package sws.songpin.domain.member.dto.response;
 
 public record LoginResponseDto(
         String accessToken,
-        String refreshToekn
+        String refreshToken
 ) { }

--- a/src/main/java/sws/songpin/domain/member/dto/response/LoginResponseDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/response/LoginResponseDto.java
@@ -1,0 +1,6 @@
+package sws.songpin.domain.member.dto.response;
+
+public record LoginResponseDto(
+        String accessToken,
+        String refreshToekn
+) { }

--- a/src/main/java/sws/songpin/domain/member/entity/Member.java
+++ b/src/main/java/sws/songpin/domain/member/entity/Member.java
@@ -33,7 +33,7 @@ public class Member extends BaseTimeEntity {
     @NotBlank
     private String password;
 
-    @Column(name = "nickname", length = 10)
+    @Column(name = "nickname", length = 8)
     @NotNull
     @NotBlank
     private String nickname;

--- a/src/main/java/sws/songpin/domain/member/service/AuthService.java
+++ b/src/main/java/sws/songpin/domain/member/service/AuthService.java
@@ -7,6 +7,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import sws.songpin.domain.member.dto.request.LoginRequestDto;
 import sws.songpin.domain.member.dto.request.SignUpRequestDto;
 import sws.songpin.domain.member.dto.response.LoginResponseDto;
@@ -20,6 +21,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class AuthService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;

--- a/src/main/java/sws/songpin/domain/member/service/AuthService.java
+++ b/src/main/java/sws/songpin/domain/member/service/AuthService.java
@@ -1,0 +1,66 @@
+package sws.songpin.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import sws.songpin.domain.member.dto.request.LoginRequestDto;
+import sws.songpin.domain.member.dto.request.SignUpRequestDto;
+import sws.songpin.domain.member.dto.response.LoginResponseDto;
+import sws.songpin.domain.member.entity.Member;
+import sws.songpin.domain.member.repository.MemberRepository;
+import sws.songpin.global.auth.JwtUtil;
+import sws.songpin.global.exception.CustomException;
+import sws.songpin.global.exception.ErrorCode;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    public void signUp(SignUpRequestDto requestDto) {
+
+        //이메일 중복 검사
+        if (memberRepository.findByEmail(requestDto.email()).isPresent()) {
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        //비밀번호 일치 검사
+        if (!requestDto.password().equals(requestDto.confirmPassword())) {
+            throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
+        }
+
+        //handle 랜덤값 생성
+        String handle = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 12);
+
+        //Member 객체 생성 후 저장
+        Member member = requestDto.toEntity(handle, passwordEncoder.encode(requestDto.password()));
+        memberRepository.save(member);
+    }
+
+    public LoginResponseDto login(LoginRequestDto requestDto){
+
+        try{
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            requestDto.email(), requestDto.password()
+                    )
+            );
+
+            LoginResponseDto responseDto = new LoginResponseDto(jwtUtil.generateAccessToken(authentication), jwtUtil.generateRefreshToken(authentication) );
+
+            return responseDto;
+        } catch (BadCredentialsException e){
+            throw new CustomException(ErrorCode.LOGIN_FAIL);
+        }
+    }
+
+}

--- a/src/main/java/sws/songpin/domain/member/service/MemberService.java
+++ b/src/main/java/sws/songpin/domain/member/service/MemberService.java
@@ -23,9 +23,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final AuthenticationManager authenticationManager;
-    private final JwtUtil jwtUtil;
 
     //개발 진행을 위한 임시 메서드
     public Member getCurrentMember(){
@@ -34,43 +31,6 @@ public class MemberService {
 
     public Member getMemberById(Long memberId){
         return memberRepository.findById(memberId).get();
-    }
-
-    public void signUp(SignUpRequestDto requestDto) {
-
-        //이메일 중복 검사
-        if (memberRepository.findByEmail(requestDto.email()).isPresent()) {
-            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
-        }
-
-        //비밀번호 일치 검사
-        if (!requestDto.password().equals(requestDto.confirmPassword())) {
-            throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
-        }
-
-        //handle 랜덤값 생성
-        String handle = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 12);
-
-        //Member 객체 생성 후 저장
-        Member member = requestDto.toEntity(handle, passwordEncoder.encode(requestDto.password()));
-        memberRepository.save(member);
-    }
-
-    public LoginResponseDto login(LoginRequestDto requestDto){
-
-        try{
-            Authentication authentication = authenticationManager.authenticate(
-                    new UsernamePasswordAuthenticationToken(
-                            requestDto.email(), requestDto.password()
-                    )
-            );
-
-            LoginResponseDto responseDto = new LoginResponseDto(jwtUtil.generateAccessToken(authentication), jwtUtil.generateRefreshToken(authentication) );
-
-            return responseDto;
-        } catch (BadCredentialsException e){
-            throw new CustomException(ErrorCode.LOGIN_FAIL);
-        }
     }
 
 }

--- a/src/main/java/sws/songpin/domain/member/service/MemberService.java
+++ b/src/main/java/sws/songpin/domain/member/service/MemberService.java
@@ -1,11 +1,18 @@
 package sws.songpin.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import sws.songpin.domain.member.dto.request.LoginRequestDto;
+import sws.songpin.domain.member.dto.response.LoginResponseDto;
 import sws.songpin.domain.member.entity.Member;
 import sws.songpin.domain.member.dto.request.SignUpRequestDto;
 import sws.songpin.domain.member.repository.MemberRepository;
+import sws.songpin.global.auth.JwtUtil;
 import sws.songpin.global.exception.CustomException;
 import sws.songpin.global.exception.ErrorCode;
 
@@ -17,6 +24,8 @@ import java.util.UUID;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
 
     //개발 진행을 위한 임시 메서드
     public Member getCurrentMember(){
@@ -45,6 +54,23 @@ public class MemberService {
         //Member 객체 생성 후 저장
         Member member = requestDto.toEntity(handle, passwordEncoder.encode(requestDto.password()));
         memberRepository.save(member);
+    }
+
+    public LoginResponseDto login(LoginRequestDto requestDto){
+
+        try{
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            requestDto.email(), requestDto.password()
+                    )
+            );
+
+            LoginResponseDto responseDto = new LoginResponseDto(jwtUtil.generateAccessToken(authentication), jwtUtil.generateRefreshToken(authentication) );
+
+            return responseDto;
+        } catch (BadCredentialsException e){
+            throw new CustomException(ErrorCode.LOGIN_FAIL);
+        }
     }
 
 }

--- a/src/main/java/sws/songpin/global/auth/CustomUserDetails.java
+++ b/src/main/java/sws/songpin/global/auth/CustomUserDetails.java
@@ -1,0 +1,31 @@
+package sws.songpin.global.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import sws.songpin.domain.member.entity.Member;
+
+import java.util.Collection;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+}

--- a/src/main/java/sws/songpin/global/auth/CustomUserDetailsService.java
+++ b/src/main/java/sws/songpin/global/auth/CustomUserDetailsService.java
@@ -1,0 +1,26 @@
+package sws.songpin.global.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sws.songpin.domain.member.entity.Member;
+import sws.songpin.domain.member.repository.MemberRepository;
+import sws.songpin.global.exception.CustomException;
+import sws.songpin.global.exception.ErrorCode;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws CustomException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(()-> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        return new CustomUserDetails(member);
+    }
+}

--- a/src/main/java/sws/songpin/global/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/sws/songpin/global/auth/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,18 @@
+package sws.songpin.global.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized: Authentication token was either missing or invalid.");
+    }
+}

--- a/src/main/java/sws/songpin/global/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/sws/songpin/global/auth/JwtAuthenticationEntryPoint.java
@@ -3,16 +3,37 @@ package sws.songpin.global.auth;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.json.JSONObject;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+import sws.songpin.global.exception.ErrorCode;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized: Authentication token was either missing or invalid.");
+        Object exception = request.getAttribute("exception");
+        if(exception instanceof  ErrorCode){
+            ErrorCode errorCode = (ErrorCode) exception;
+            setResponse(response,errorCode);
+            return;
+        }
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException{
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("timestamp", LocalDateTime.now().toString());
+        jsonObject.put("status",errorCode.getStatus());
+        jsonObject.put("errorCode", errorCode.name());
+        jsonObject.put("message", errorCode.getMessage());
+        response.getWriter().println(jsonObject);
+
     }
 }

--- a/src/main/java/sws/songpin/global/auth/JwtFilter.java
+++ b/src/main/java/sws/songpin/global/auth/JwtFilter.java
@@ -1,5 +1,7 @@
 package sws.songpin.global.auth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -7,13 +9,17 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import sws.songpin.global.exception.CustomException;
 import sws.songpin.global.exception.ErrorCode;
+import sws.songpin.global.exception.ErrorDto;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Log4j2
@@ -35,15 +41,11 @@ public class JwtFilter extends OncePerRequestFilter {
                 }
             } catch (RedisConnectionFailureException e){
                 SecurityContextHolder.clearContext();
-                throw new CustomException(ErrorCode.EXTERNAL_API_ERROR);
-            } catch (Exception e){
-                throw new CustomException(ErrorCode.INVALID_TOKEN);
+                request.setAttribute("exception",ErrorCode.EXTERNAL_API_ERROR);
+            } catch (CustomException e){
+                request.setAttribute("exception",e.getErrorCode());
             }
-
         }
-
         filterChain.doFilter(request,response);
-
-
     }
 }

--- a/src/main/java/sws/songpin/global/auth/JwtUtil.java
+++ b/src/main/java/sws/songpin/global/auth/JwtUtil.java
@@ -1,9 +1,6 @@
 package sws.songpin.global.auth;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -80,11 +77,10 @@ public class JwtUtil {
         try {
             Jwts.parserBuilder().setSigningKey(accessKey).build().parseClaimsJws(token);
             return true;
-        } catch (ExpiredJwtException e){
+        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e){
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
             throw new CustomException(ErrorCode.EXPIRED_TOKEN);
-        }
-        catch (Exception e){
-            return false;
         }
     }
 

--- a/src/main/java/sws/songpin/global/auth/JwtUtil.java
+++ b/src/main/java/sws/songpin/global/auth/JwtUtil.java
@@ -1,0 +1,101 @@
+package sws.songpin.global.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import sws.songpin.global.exception.CustomException;
+import sws.songpin.global.exception.ErrorCode;
+
+import java.security.Key;
+import java.time.Duration;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private final Key accessKey;
+    private final Key refreshKey;
+    private final RedisTemplate<String,Object> redisTemplate;
+    private final CustomUserDetailsService userDetailsService;
+    private static final Duration ACCESS_TOKEN_EXPIRE_TIME = Duration.ofMinutes(30); //30분
+    private static final Duration REFRESH_TOKEN_EXPIRE_TIME = Duration.ofDays(7); //7일
+
+    public JwtUtil(@Value("${jwt.secret.access}") String accessSecret, @Value("${jwt.secret.refresh}") String refreshSecret, CustomUserDetailsService userDetailsService,RedisTemplate<String,Object> redisTemplate){
+        byte[] keyBytes = Decoders.BASE64.decode(accessSecret);
+        this.accessKey = Keys.hmacShaKeyFor(keyBytes);
+        keyBytes = Decoders.BASE64.decode(refreshSecret);
+        this.refreshKey = Keys.hmacShaKeyFor(keyBytes);
+        this.redisTemplate = redisTemplate;
+        this.userDetailsService = userDetailsService;
+    }
+
+    public String generateAccessToken(Authentication authentication){
+
+        Claims claims = Jwts.claims();
+        claims.setSubject(authentication.getName());
+
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime()+ACCESS_TOKEN_EXPIRE_TIME.toMillis());
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expireDate)
+                .signWith(accessKey, SignatureAlgorithm.HS256)
+                .compact();
+
+    }
+
+    public String generateRefreshToken(Authentication authentication){
+
+        Claims claims = Jwts.claims();
+        claims.setSubject(authentication.getName());
+
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime()+REFRESH_TOKEN_EXPIRE_TIME.toMillis());
+
+        String refreshToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expireDate)
+                .signWith(refreshKey,SignatureAlgorithm.HS256)
+                .compact();
+
+        //refresh token을 redis에 저장
+        redisTemplate.opsForValue().set(authentication.getName(),refreshToken,REFRESH_TOKEN_EXPIRE_TIME);
+
+        return refreshToken;
+    }
+
+
+    public boolean validateToken(String token){
+        try {
+            Jwts.parserBuilder().setSigningKey(accessKey).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e){
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
+        }
+        catch (Exception e){
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String token){
+        String userPrincipal = Jwts.parserBuilder()
+                .setSigningKey(accessKey)
+                .build().parseClaimsJws(token)
+                .getBody().getSubject();
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userPrincipal);
+
+        return new UsernamePasswordAuthenticationToken(userDetails,"",userDetails.getAuthorities());
+    }
+
+}

--- a/src/main/java/sws/songpin/global/config/RedisConfig.java
+++ b/src/main/java/sws/songpin/global/config/RedisConfig.java
@@ -1,0 +1,54 @@
+package sws.songpin.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host,port);
+        config.setPassword(password);
+        return new LettuceConnectionFactory(config); //RedisConnectionFactory를 통해 내장 혹은 외부의 Redis 연결
+    }
+
+    @Bean
+    public RedisTemplate<String,Object> redisTemplate(){
+        RedisTemplate<String,Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory()); //redis와 스프링 연결 관리
+
+        //아래 메서드들을 설정하지 않으면 스프링 값들이 redis에 바이트 값으로 저장됨 (기본 (역)직렬화 설정이 JDK 직렬화 방식이기 때문)
+        //redis-cli를 통해 직접 데이터를 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
+
+        //일반적인 key:value 의 경우 serializer
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        //hash를 사용할 경우 serializer
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        //모든 경우
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -3,7 +3,9 @@ package sws.songpin.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -11,18 +13,30 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import sws.songpin.global.auth.JwtAuthenticationEntryPoint;
+import sws.songpin.global.auth.JwtFilter;
+import sws.songpin.global.auth.JwtUtil;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtUtil jwtUtil;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
     private static final String[] AUTH_WHITELIST = {
-            "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs","/v3/api-docs/**"
+            "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs","/v3/api-docs/**",
+            "/signup","/login"
     };
 
     @Bean
     public PasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();
+    }
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception{
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
     @Bean
@@ -35,9 +49,12 @@ public class SecurityConfig {
                 .sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .headers(header -> header
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
-//                .authorizeHttpRequests(auth->auth
-//                        .requestMatchers(AUTH_WHITELIST).permitAll()
-//                        .anyRequest().authenticated())
+                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .authorizeHttpRequests(auth->auth
+                        .requestMatchers(AUTH_WHITELIST).permitAll()
+                        .anyRequest().authenticated())
+                .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+
         ;
 
         return http.build();

--- a/src/main/java/sws/songpin/global/config/SwaggerConfig.java
+++ b/src/main/java/sws/songpin/global/config/SwaggerConfig.java
@@ -21,23 +21,23 @@ import java.util.Arrays;
 public class SwaggerConfig {
 
 
-//    @Bean
-//    public OpenAPI openAPI(){
-//        //Security 스키마 설정
-//        SecurityScheme bearerAuth = new SecurityScheme()
-//                .type(SecurityScheme.Type.HTTP)
-//                .scheme("bearer")
-//                .bearerFormat("JWT")
-//                .in(SecurityScheme.In.HEADER)
-//                .name(HttpHeaders.AUTHORIZATION);
-//
-//        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
-//
-//        return new OpenAPI()
-//                .components(new Components()
-//                        .addSecuritySchemes("bearerAuth",bearerAuth))
-//                .security(Arrays.asList(securityRequirement));
-//    }
+    @Bean
+    public OpenAPI openAPI(){
+        //Security 스키마 설정
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",bearerAuth))
+                .security(Arrays.asList(securityRequirement));
+    }
 
 
     @Bean

--- a/src/main/java/sws/songpin/global/exception/ErrorCode.java
+++ b/src/main/java/sws/songpin/global/exception/ErrorCode.java
@@ -21,8 +21,6 @@ public enum ErrorCode {
     PASSWORD_MISMATCH(400, "비밀번호가 일치하지 않습니다."),
     // enum 값이 잘못됨 (Visibility, GenreName, SortBy)
     INVALID_ENUM_VALUE(400, "enum 값이 잘못되었습니다."),
-    // 유효하지 않은 토큰
-    INVALID_TOKEN(400, "유효하지 않은 토큰입니다."),
     // 자신과 관련해 불가능한 요청
     MEMBER_BAD_REQUEST(400, "자기 자신은 이 경로를 통해 조회할 수 없습니다."),
     FOLLOW_BAD_REQUEST(400,"팔로잉을 처리할 수 없습니다."),
@@ -32,6 +30,12 @@ public enum ErrorCode {
     NOT_AUTHENTICATED(401, "로그인 상태가 아닙니다."),
     // 권한이 없는 요청을 보냄
     UNAUTHORIZED_REQUEST(401,"권한이 없습니다."),
+    // 로그인 시 잘못된 패스워드 입력
+    LOGIN_FAIL(401, "로그인에 실패했습니다."),
+    // 유효하지 않은 토큰
+    INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
+    // 만료된 토큰
+    EXPIRED_TOKEN(401,"만료된 토큰입니다."),
 
     // 404 Not Found
     // 각 리소스를 찾지 못함


### PR DESCRIPTION
# 구현 기능
  - JWT 발급 
  - JWT 검증
  - 로그인 API 

# 구현 상태 
- 유저가 로그인 시 Access Token과 Refresh Token 발급, 이때 Refresh Token은 Redis에 키(email):값(token) 쌍으로 저장
- Access Token 과 Refresh Token 의 서명에 쓰이는 비밀키는 각각 다르게 구현
---
- 로그인 API 응답
1. 로그인하는 이메일이 DB에 존재하지 않을 때
```json
{
  "timestamp": "2024-07-08T15:48:20.479449900",
  "status": 404,
  "errorCode": "MEMBER_NOT_FOUND",
  "message": "사용자를 찾을 수 없습니다.",
  "path": "/login"
}
```
2. 패스워드가 틀렸을 때
```json
{
  "timestamp": "2024-07-08T15:48:44.070610500",
  "status": 401,
  "errorCode": "LOGIN_FAIL",
  "message": "로그인에 실패했습니다.",
  "path": "/login"
}
```
---
- 토큰 검증 실패 시 응답
1. 만료된 토큰일 때
```json
{
  "errorCode": "EXPIRED_TOKEN",
  "message": "만료된 토큰입니다.",
  "timestamp": "2024-07-08T15:49:23.898279700",
  "status": 401
}
```
2. 유효하지 않은 토큰일 때
```json
{
  "errorCode": "INVALID_TOKEN",
  "message": "유효하지 않은 토큰입니다.",
  "timestamp": "2024-07-08T15:49:47.847155600",
  "status": 401
}
```
# Resolve
- #9 
