### PR TITLE
[Feat] bindException 에러 메시지 수정

### DIFF
--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -1,6 +1,7 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import sws.songpin.domain.member.entity.Member;
@@ -13,6 +14,7 @@ public record SignUpRequestDto(
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         String nickname,
         @Size(max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 20자 이내여야 합니다.")
+        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
         String password,
         String confirmPassword) {
     public Member toEntity(String handle, String password){

--- a/src/main/java/sws/songpin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sws/songpin/global/exception/GlobalExceptionHandler.java
@@ -31,10 +31,10 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode;
         if(errorMessage.contains("-")){
             String errorName = errorMessage.split("-")[0];
-            errorMessage = errorMessage.split("-")[1];
+            errorMessage = e.getFieldError().getField() + ":" + errorMessage.split("-")[1];
             errorCode = ErrorCode.valueOf(errorName);
         } else {
-            errorMessage = e.getFieldError().getField() + "-" + errorMessage;
+            errorMessage = e.getFieldError().getField() + ":" + errorMessage;
             errorCode = ErrorCode.INVALID_INPUT_VALUE;
         }
         ErrorDto errorDto = new ErrorDto(


### PR DESCRIPTION
# 구현 기능
  - 어떤 필드에서 @valid 조건을 충족하지 않았는지 알 수 있도록 bindException 에러 메시지 수정
  - SignUpRequestDto 비밀번호 필드에 @NotBlank 어노테이션 추가

# 구현 상태 
  - 구현 결과
  ```json
{
  "timestamp": "2024-07-10T12:33:24.769086900",
  "status": 400,
  "errorCode": "INVALID_INPUT_FORMAT",
  "message": "email:유효한 이메일 형식이 아닙니다.",
  "path": "/signup"
}
```
```json
{
  "timestamp": "2024-07-10T12:39:11.338092200",
  "status": 400,
  "errorCode": "INVALID_INPUT_LENGTH",
  "message": "email:이메일은 50자 이내여야 합니다.",
  "path": "/signup"
}
```
```json
{
  "timestamp": "2024-07-10T12:41:57.496936100",
  "status": 400,
  "errorCode": "INVALID_INPUT_FORMAT",
  "message": "nickname:닉네임은 한글 문자, 영어 대소문자, 숫자 조합만 허용됩니다.",
  "path": "/signup"
}
```
```json
{
  "timestamp": "2024-07-10T12:41:19.364763200",
  "status": 400,
  "errorCode": "INVALID_INPUT_LENGTH",
  "message": "nickname:닉네임은 8자 이내여야 합니다.",
  "path": "/signup"
}
```
```json
{
  "timestamp": "2024-07-10T12:40:19.186616600",
  "status": 400,
  "errorCode": "INVALID_INPUT_LENGTH",
  "message": "password:비밀번호는 20자 이내여야 합니다.",
  "path": "/signup"
}
```
```json
{
  "timestamp": "2024-07-10T12:47:33.477249800",
  "status": 400,
  "errorCode": "INVALID_INPUT_VALUE",
  "message": "password:비밀번호는 한 글자 이상 입력해야 합니다.",
  "path": "/signup"
}
```

# Resolve
- #32
