### PR TITLE
[Feat] 플레이리스트 메인, 플레이리스트 검색 

### DIFF
--- a/src/main/java/sws/songpin/domain/playlist/controller/PlaylistController.java
+++ b/src/main/java/sws/songpin/domain/playlist/controller/PlaylistController.java
@@ -4,9 +4,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import sws.songpin.domain.model.SortBy;
 import sws.songpin.domain.playlist.dto.request.PlaylistAddRequestDto;
 import sws.songpin.domain.playlist.dto.request.PlaylistUpdateRequestDto;
 import sws.songpin.domain.playlist.dto.request.PlaylistPinAddRequestDto;
@@ -53,6 +56,20 @@ public class PlaylistController {
     public ResponseEntity<?> deletePlaylist(@PathVariable("playlistId") final Long playlistId) {
         playlistService.deletePlaylist(playlistId);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "플레이리스트 메인", description = "플레이리스트 메인 페이지 조회")
+    @GetMapping("/main")
+    public ResponseEntity<?> getPlaylistMain() {
+        return ResponseEntity.ok(playlistService.getPlaylistMain());
+    }
+
+    @Operation(summary = "플레이리스트 검색", description = "플레이리스트 검색 결과를 선택한 정렬 기준에 따라 페이징으로 불러옵니다.")
+    @GetMapping
+    public ResponseEntity<?> playlistSearch(@RequestParam final String keyword,
+                                         @RequestParam(defaultValue = "ACCURACY") final String sortBy,
+                                         @PageableDefault(size = 20) final Pageable pageable) {
+        return ResponseEntity.ok().body(playlistService.searchPlaylists(keyword, SortBy.from(sortBy), pageable));
     }
 
 

--- a/src/main/java/sws/songpin/domain/playlist/controller/PlaylistController.java
+++ b/src/main/java/sws/songpin/domain/playlist/controller/PlaylistController.java
@@ -1,6 +1,7 @@
 package sws.songpin.domain.playlist.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import sws.songpin.domain.playlist.dto.request.PlaylistPinAddRequestDto;
 import sws.songpin.domain.playlist.service.PlaylistService;
 import sws.songpin.domain.playlistpin.service.PlaylistPinService;
 
+@Tag(name = "Playlist", description = "Playlist 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/playlists")

--- a/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistDetailsResponseDto.java
+++ b/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistDetailsResponseDto.java
@@ -2,6 +2,8 @@ package sws.songpin.domain.playlist.dto.response;
 
 import sws.songpin.domain.model.Visibility;
 import sws.songpin.domain.playlist.entity.Playlist;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -10,7 +12,7 @@ public record PlaylistDetailsResponseDto(
         String playlistName,
         Long creatorId,
         String creatorNickname,
-        LocalDateTime updatedDate,
+        LocalDate updatedDate,
         Visibility visibility,
         List<String> imgPathList,
         Long bookmarkId,
@@ -22,7 +24,7 @@ public record PlaylistDetailsResponseDto(
                 playlist.getPlaylistName(),
                 playlist.getCreator().getMemberId(),
                 playlist.getCreator().getNickname(),
-                playlist.getModifiedTime(),
+                playlist.getModifiedTime().toLocalDate(),
                 playlist.getVisibility(),
                 imgPathList,
                 bookmarkId,

--- a/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistDetailsResponseDto.java
+++ b/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistDetailsResponseDto.java
@@ -1,11 +1,7 @@
 package sws.songpin.domain.playlist.dto.response;
 
-import sws.songpin.domain.genre.entity.GenreName;
 import sws.songpin.domain.model.Visibility;
 import sws.songpin.domain.playlist.entity.Playlist;
-import sws.songpin.domain.song.dto.response.SongInfoDto;
-
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -18,9 +14,9 @@ public record PlaylistDetailsResponseDto(
         Visibility visibility,
         List<String> imgPathList,
         Long bookmarkId,
-        List<PlaylistPinListDto> pinList) {
+        List<PlaylistPinUnitDto> pinList) {
 
-    public static PlaylistDetailsResponseDto from(Playlist playlist, List<String> imgPathList, List<PlaylistPinListDto> pinList, Boolean isMine, Long bookmarkId) {
+    public static PlaylistDetailsResponseDto from(Playlist playlist, List<String> imgPathList, List<PlaylistPinUnitDto> pinList, Boolean isMine, Long bookmarkId) {
         return new PlaylistDetailsResponseDto(
                 isMine,
                 playlist.getPlaylistName(),
@@ -32,17 +28,6 @@ public record PlaylistDetailsResponseDto(
                 bookmarkId,
                 pinList
         );
-    }
-
-    public record PlaylistPinListDto(
-            Long playlistPinId,
-            Long pinId,
-            SongInfoDto songInfo,
-            LocalDate listenedDate,
-            String placeName,
-            Long providerAddressId,
-            GenreName genreName,
-            int pinIndex) {
     }
 
 }

--- a/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistMainResponseDto.java
+++ b/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistMainResponseDto.java
@@ -1,0 +1,19 @@
+package sws.songpin.domain.playlist.dto.response;
+
+import java.util.List;
+
+public record PlaylistMainResponseDto(
+        int recentPlaylistsCount,
+        List<PlaylistUnitDto> recentPlaylists,
+        int followingPlaylistsCount,
+        List<PlaylistUnitDto> followingPlaylists) {
+
+    public static PlaylistMainResponseDto from(List<PlaylistUnitDto> recentPlaylists, List<PlaylistUnitDto> followingPlaylists) {
+        return new PlaylistMainResponseDto(
+                recentPlaylists.size(),
+                recentPlaylists,
+                followingPlaylists.size(),
+                followingPlaylists
+        );
+    }
+}

--- a/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistPinUnitDto.java
+++ b/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistPinUnitDto.java
@@ -1,0 +1,16 @@
+package sws.songpin.domain.playlist.dto.response;
+
+import sws.songpin.domain.genre.entity.GenreName;
+import sws.songpin.domain.song.dto.response.SongInfoDto;
+import java.time.LocalDate;
+
+public record PlaylistPinUnitDto(
+        Long playlistPinId,
+        Long pinId,
+        SongInfoDto songInfo,
+        LocalDate listenedDate,
+        String placeName,
+        Long providerAddressId,
+        GenreName genreName,
+        int pinIndex) {
+}

--- a/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistSearchResponseDto.java
+++ b/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistSearchResponseDto.java
@@ -9,16 +9,14 @@ public record PlaylistSearchResponseDto(
         int pageSize, // 현재 페이지 크기
         long totalElements,
         int totalPages,
-        long playlistCount,
         List<PlaylistUnitDto> playlists) {
 
-    public static PlaylistSearchResponseDto from(long playlistCount, Page<PlaylistUnitDto> playlistUnitPage) {
+    public static PlaylistSearchResponseDto from(Page<PlaylistUnitDto> playlistUnitPage) {
         return new PlaylistSearchResponseDto(
                 playlistUnitPage.getNumber(),
                 playlistUnitPage.getSize(),
                 playlistUnitPage.getTotalElements(),
                 playlistUnitPage.getTotalPages(),
-                playlistCount,
                 playlistUnitPage.getContent()
         );
     }

--- a/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistSearchResponseDto.java
+++ b/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistSearchResponseDto.java
@@ -1,0 +1,25 @@
+package sws.songpin.domain.playlist.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PlaylistSearchResponseDto(
+        int currentPage,
+        int pageSize, // 현재 페이지 크기
+        long totalElements,
+        int totalPages,
+        long playlistCount,
+        List<PlaylistUnitDto> playlists) {
+
+    public static PlaylistSearchResponseDto from(long playlistCount, Page<PlaylistUnitDto> playlistUnitPage) {
+        return new PlaylistSearchResponseDto(
+                playlistUnitPage.getNumber(),
+                playlistUnitPage.getSize(),
+                playlistUnitPage.getTotalElements(),
+                playlistUnitPage.getTotalPages(),
+                playlistCount,
+                playlistUnitPage.getContent()
+        );
+    }
+}

--- a/src/main/java/sws/songpin/domain/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/sws/songpin/domain/playlist/repository/PlaylistRepository.java
@@ -28,7 +28,7 @@ public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
             "LEFT JOIN playlist_pin pin ON p.playlist_id = pin.playlist_id " +
             "WHERE REPLACE(p.playlist_name, ' ', '') LIKE %:keywordNoSpaces% " +
             "GROUP BY p.playlist_id " +
-            "ORDER BY MAX(pin.created_time) DESC",
+            "ORDER BY MAX(p.modified_time) DESC",
             nativeQuery = true)
     Page<Object[]> findAllByPlaylistNameContainingIgnoreSpacesOrderByNewest(@Param("keywordNoSpaces") String keywordNoSpaces, Pageable pageable);
 

--- a/src/main/java/sws/songpin/domain/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/sws/songpin/domain/playlist/repository/PlaylistRepository.java
@@ -1,6 +1,10 @@
 package sws.songpin.domain.playlist.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sws.songpin.domain.member.entity.Member;
 import sws.songpin.domain.playlist.entity.Playlist;
 
@@ -8,4 +12,32 @@ import java.util.List;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
     List<Playlist> findAllByCreator(Member member);
+
+
+    @Query(value = "SELECT p.playlist_id, p.playlist_name, COUNT(pin.pin_id) AS pin_count " +
+            "FROM playlist p " +
+            "LEFT JOIN playlist_pin pin ON p.playlist_id = pin.playlist_id " +
+            "WHERE REPLACE(p.playlist_name, ' ', '') LIKE %:keywordNoSpaces% " +
+            "GROUP BY p.playlist_id " +
+            "ORDER BY pin_count DESC, p.playlist_name ASC",
+            nativeQuery = true)
+    Page<Object[]> findAllByPlaylistNameContainingIgnoreSpacesOrderByCount(@Param("keywordNoSpaces") String keywordNoSpaces, Pageable pageable);
+
+    @Query(value = "SELECT p.playlist_id, p.playlist_name, COUNT(pin.pin_id) AS pin_count " +
+            "FROM playlist p " +
+            "LEFT JOIN playlist_pin pin ON p.playlist_id = pin.playlist_id " +
+            "WHERE REPLACE(p.playlist_name, ' ', '') LIKE %:keywordNoSpaces% " +
+            "GROUP BY p.playlist_id " +
+            "ORDER BY MAX(pin.created_time) DESC",
+            nativeQuery = true)
+    Page<Object[]> findAllByPlaylistNameContainingIgnoreSpacesOrderByNewest(@Param("keywordNoSpaces") String keywordNoSpaces, Pageable pageable);
+
+    @Query(value = "SELECT p.playlist_id, p.playlist_name, COUNT(pin.pin_id) AS pin_count " +
+            "FROM playlist p " +
+            "LEFT JOIN playlist_pin pin ON p.playlist_id = pin.playlist_id " +
+            "WHERE REPLACE(p.playlist_name, ' ', '') LIKE %:keywordNoSpaces% " +
+            "GROUP BY p.playlist_id " +
+            "ORDER BY p.playlist_name ASC",
+            nativeQuery = true)
+    Page<Object[]> findAllByPlaylistNameContainingIgnoreSpacesOrderByAccuracy(@Param("keywordNoSpaces") String keywordNoSpaces, Pageable pageable);
 }

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -56,7 +56,7 @@ public class PlaylistService {
         Playlist playlist = findPlaylistById(playlistId);
         List<PlaylistPin> playlistPinList = playlist.getPlaylistPins();
         // imgPathList, pinList
-        List<PlaylistDetailsResponseDto.PlaylistPinListDto> pinList = new ArrayList<>();
+        List<PlaylistPinUnitDto> pinList = new ArrayList<>();
         List<String> imgPathList = new ArrayList<>();
 
         playlistPinList.stream()
@@ -64,7 +64,7 @@ public class PlaylistService {
                 .forEach(playlistPin -> {
                     // SongInfo
                     SongInfoDto songInfo = SongInfoDto.from(playlistPin.getPin().getSong());
-                    PlaylistDetailsResponseDto.PlaylistPinListDto pinListDto = new PlaylistDetailsResponseDto.PlaylistPinListDto(
+                    PlaylistPinUnitDto pinListDto = new PlaylistPinUnitDto(
                             playlistPin.getPlaylistPinId(),
                             playlistPin.getPin().getPinId(),
                             songInfo,

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -2,12 +2,17 @@ package sws.songpin.domain.playlist.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sws.songpin.domain.bookmark.entity.Bookmark;
 import sws.songpin.domain.bookmark.repository.BookmarkRepository;
+import sws.songpin.domain.follow.service.FollowService;
 import sws.songpin.domain.member.entity.Member;
+import sws.songpin.domain.follow.entity.Follow;
 import sws.songpin.domain.member.service.MemberService;
+import sws.songpin.domain.model.SortBy;
 import sws.songpin.domain.model.Visibility;
 import sws.songpin.domain.playlist.dto.response.*;
 import sws.songpin.domain.playlist.dto.request.PlaylistAddRequestDto;
@@ -34,6 +39,7 @@ public class PlaylistService {
     private final PlaylistRepository playlistRepository;
     private final PlaylistPinRepository playlistPinRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final FollowService followService;
 
     // 플레이리스트 생성
     public PlaylistAddResponseDto createPlaylist(PlaylistAddRequestDto requestDto) {
@@ -185,5 +191,66 @@ public class PlaylistService {
                 .map(playlistPin -> playlistPin.getPin().getSong().getImgPath())
                 .limit(3)
                 .collect(Collectors.toList());
+    }
+
+    // 플레이리스트 메인 페이지 조회
+    @Transactional(readOnly = true)
+    public PlaylistMainResponseDto getPlaylistMain() {
+        Member currentMember = memberService.getCurrentMember();
+        List<Playlist> allPlaylists = playlistRepository.findAll();
+
+        // recentPlaylists
+        List<PlaylistUnitDto> recentPlaylists = allPlaylists.stream()
+                .filter(playlist -> playlist.getVisibility() == Visibility.PUBLIC || playlist.getCreator().equals(currentMember))
+                .sorted((p1, p2) -> Long.compare(p2.getPlaylistId(), p1.getPlaylistId()))
+                .limit(4)
+                .map(playlist -> {
+                    List<String> imgPathList = getPlaylistThumbnailImgPathList(playlist);
+                    boolean isBookmarked = bookmarkRepository.existsByPlaylistAndMember(playlist, currentMember);
+                    return PlaylistUnitDto.from(playlist, imgPathList, isBookmarked);
+                })
+                .collect(Collectors.toList());
+
+        // followingPlaylists
+        List<Follow> followings = followService.findAllFollowingOfMember(currentMember);
+        List<Member> followingMembers = followings.stream()
+                .map(Follow::getFollowing)
+                .collect(Collectors.toList());
+        List<PlaylistUnitDto> followingPlaylists = allPlaylists.stream()
+                .filter(playlist -> followingMembers.contains(playlist.getCreator()) && playlist.getVisibility() == Visibility.PUBLIC)
+                .sorted((p1, p2) -> Long.compare(p2.getPlaylistId(), p1.getPlaylistId()))
+                .limit(4)
+                .map(playlist -> {
+                    List<String> imgPathList = getPlaylistThumbnailImgPathList(playlist);
+                    boolean isBookmarked = bookmarkRepository.existsByPlaylistAndMember(playlist, currentMember);
+                    return PlaylistUnitDto.from(playlist, imgPathList, isBookmarked);
+                })
+                .collect(Collectors.toList());
+
+        return PlaylistMainResponseDto.from(recentPlaylists, followingPlaylists);
+    }
+
+    // 플레이리스트 검색
+    @Transactional(readOnly = true)
+    public Object searchPlaylists(String keyword, SortBy sortBy, Pageable pageable) {
+        String keywordNoSpaces = keyword.replace(" ", "");
+        Page<Object[]> playlistPage;
+        switch (sortBy) {
+            case COUNT -> playlistPage = playlistRepository.findAllByPlaylistNameContainingIgnoreSpacesOrderByCount(keywordNoSpaces, pageable);
+            case NEWEST -> playlistPage = playlistRepository.findAllByPlaylistNameContainingIgnoreSpacesOrderByNewest(keywordNoSpaces, pageable);
+            case ACCURACY -> playlistPage = playlistRepository.findAllByPlaylistNameContainingIgnoreSpacesOrderByAccuracy(keywordNoSpaces, pageable);
+            default -> throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
+        // Page<Object[]>를 Page<PlaylistUnitDto>로 변환
+        Page<PlaylistUnitDto> playlistUnitPage = playlistPage.map(objects -> {
+            Member currentMember = memberService.getCurrentMember();
+            Long playlistId = ((Number) objects[0]).longValue();
+            Playlist playlist = findPlaylistById(playlistId);
+            List<String> imgPathList = getPlaylistThumbnailImgPathList(playlist);
+            boolean isBookmarked = bookmarkRepository.existsByPlaylistAndMember(playlist, currentMember);
+            return PlaylistUnitDto.from(playlist, imgPathList, isBookmarked);
+        });
+        // PlaylistSearchResponseDto를 반환
+        return PlaylistSearchResponseDto.from(playlistPage.getTotalElements(), playlistUnitPage);
     }
 }

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -251,6 +251,6 @@ public class PlaylistService {
             return PlaylistUnitDto.from(playlist, imgPathList, isBookmarked);
         });
         // PlaylistSearchResponseDto를 반환
-        return PlaylistSearchResponseDto.from(playlistPage.getTotalElements(), playlistUnitPage);
+        return PlaylistSearchResponseDto.from(playlistUnitPage);
     }
 }


### PR DESCRIPTION
# 구현 기능
  - Playlist - 플레이리스트 메인
  - Playlist - 플레이리스트 검색 

# 구현 상태 
  - 이전 PR#38의 코드 리뷰 반영 
  - Place 장소 검색 코드를 수정하여 Playlist 검색에 적용함 
  - 플레이리스트 메인 URI를 /playlists/main으로 수정 (API 명세서 수정 완료)

# Resolve
  - #31 
