### PR TITLE
[Feat] 내 정보 조회 API 구현

### DIFF
--- a/src/main/java/sws/songpin/domain/member/controller/MyPageController.java
+++ b/src/main/java/sws/songpin/domain/member/controller/MyPageController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sws.songpin.domain.bookmark.service.BookmarkService;
+import sws.songpin.domain.member.service.ProfileService;
 import sws.songpin.domain.playlist.service.PlaylistService;
 
 @Tag(name = "MyPage", description = "MyPage 관련 API입니다.")
@@ -15,6 +16,7 @@ import sws.songpin.domain.playlist.service.PlaylistService;
 public class MyPageController {
     private final PlaylistService playlistService;
     private final BookmarkService bookmarkService;
+    private final ProfileService profileService;
 
     @Operation(summary = "내 플레이리스트 목록 조회", description = "마이페이지에서 내 플레이리스트 목록 조회")
     @GetMapping("/me/playlists")
@@ -28,4 +30,9 @@ public class MyPageController {
         return ResponseEntity.ok(bookmarkService.getAllBookmarks());
     }
 
+    @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 프로필 이미지, 닉네임, 아이디 정보 조회")
+    @GetMapping
+    public ResponseEntity<?> getMyProfile(){
+        return ResponseEntity.ok(profileService.getMyProfile());
+    }
 }

--- a/src/main/java/sws/songpin/domain/member/dto/response/MyProfileResponseDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/response/MyProfileResponseDto.java
@@ -1,0 +1,16 @@
+package sws.songpin.domain.member.dto.response;
+
+import sws.songpin.domain.member.entity.Member;
+import sws.songpin.domain.member.entity.ProfileImg;
+
+public record MyProfileResponseDto(
+        ProfileImg profileImg,
+        String nickname,
+        String handle,
+        long follower,
+        long following
+) {
+    public static MyProfileResponseDto from(Member member, long followerCount, long followingCount){
+        return new MyProfileResponseDto(member.getProfileImg(), member.getNickname(), member.getHandle(), followerCount, followingCount);
+    }
+}

--- a/src/main/java/sws/songpin/domain/member/service/ProfileService.java
+++ b/src/main/java/sws/songpin/domain/member/service/ProfileService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import sws.songpin.domain.follow.service.FollowService;
 import sws.songpin.domain.member.dto.response.MemberResponseDto;
+import sws.songpin.domain.member.dto.response.MyProfileResponseDto;
 import sws.songpin.domain.member.entity.Member;
 import sws.songpin.global.exception.CustomException;
 import sws.songpin.global.exception.ErrorCode;
@@ -36,5 +37,17 @@ public class ProfileService {
 
         return MemberResponseDto.from(member, followerCount, followingCount, followId);
 
+    }
+
+    public MyProfileResponseDto getMyProfile(){
+        Member member = memberService.getCurrentMember();
+
+        //팔로워 수
+        long followerCount = followService.getFollowerCount(member);
+
+        //팔로잉 수
+        long followingCount = followService.getFollowingCount(member);
+
+        return MyProfileResponseDto.from(member, followerCount, followingCount);
     }
 }


### PR DESCRIPTION
# 구현 기능
  - 내 정보 조회 API 구현

# 구현 상태 
  - 성공 응답
```json
{
  "profileImg": "POP",
  "nickname": "rXbC1OC7q6",
  "handle": "725343dbb167",
  "follower": 0,
  "following": 1
}
```
  - 실패 응답 
```json
{
  "timestamp": "2024-07-17T01:37:36.435001300",
  "status": 401,
  "errorCode": "NOT_AUTHENTICATED",
  "message": "로그인 상태가 아닙니다.",
  "path": "/me"
}
```

# Resolve
  - #9 
