### PR TITLE
[Feat] Spring Security에 공유 가능한 uri 추가

### DIFF
--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package sws.songpin.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -39,7 +40,7 @@ public class SecurityConfig {
     };
 
     @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() { // security를 적용하지 않을 리소스
+    public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
                 .requestMatchers("/error", "/favicon.ico")
                 .requestMatchers(AUTH_WHITELIST);
@@ -80,7 +81,6 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
-
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
@@ -92,10 +92,12 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AUTH_WHITELIST).permitAll()
+                        .requestMatchers(HttpMethod.GET,"/places/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/playlists/main").authenticated()
+                        .requestMatchers(HttpMethod.GET,"/playlists/**").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
         ;
-
         return http.build();
     }
 }


### PR DESCRIPTION
# 구현 기능
- 아래 부분을 추가했습니다.
  - /playlists/main는 보안이 적용되어야 하고, /playlists/**는 공개되어야 해서 순서에 유의하였습니다.
```
           .requestMatchers(HttpMethod.GET,"/places/**").permitAll()
           .requestMatchers(HttpMethod.GET,"/playlists/main").authenticated()
           .requestMatchers(HttpMethod.GET,"/playlists/**").permitAll()
```

# Resolve
  - #63 
