### PR TITLE
fix: SecurityConfig 사용하지 않는 헤더 관련 코드 삭제

### DIFF
--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -65,8 +65,6 @@ public class SecurityConfig {
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true);
 
-        configuration.addExposedHeader("Authorization");
-        configuration.addExposedHeader("Authorization-Refresh");
         configuration.addExposedHeader("Set-Cookie");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();


### PR DESCRIPTION
# 구현 기능
  - SecurityConfig 사용하지 않는 헤더 관련 코드 삭제 
  ```
        configuration.addExposedHeader("Authorization");
        configuration.addExposedHeader("Authorization-Refresh"); 