### PR TITLE
[Feat] 탈퇴한 회원 정보 처리

### DIFF
--- a/src/main/java/sws/songpin/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/sws/songpin/domain/alarm/repository/AlarmRepository.java
@@ -9,4 +9,5 @@ import sws.songpin.domain.member.entity.Member;
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     Slice<Alarm> findByReceiverOrderByCreatedTimeDesc(Member receiver, Pageable pageable);
     Boolean existsByReceiverAndIsReadFalse(Member member);
+    void deleteAllByReceiver(Member member);
 }

--- a/src/main/java/sws/songpin/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/sws/songpin/domain/alarm/repository/AlarmRepository.java
@@ -9,5 +9,6 @@ import sws.songpin.domain.member.entity.Member;
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     Slice<Alarm> findByReceiverOrderByCreatedTimeDesc(Member receiver, Pageable pageable);
     Boolean existsByReceiverAndIsReadFalse(Member member);
+    void deleteAllBySender(Member member);
     void deleteAllByReceiver(Member member);
 }

--- a/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
@@ -53,6 +53,10 @@ public class AlarmService {
         return AlarmListResponseDto.fromAlarmUnitDto(alarmUnitDtos);
     }
 
+    public void deleteAllAlarmOfMember(Member member){
+        alarmRepository.deleteAllByReceiver(member);
+    }
+
     private List<AlarmUnitDto> getAndReadAlarms() {
         List<AlarmUnitDto> alarmList = new ArrayList<>();
         Member member = memberService.getCurrentMember();

--- a/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
@@ -53,7 +53,8 @@ public class AlarmService {
         return AlarmListResponseDto.fromAlarmUnitDto(alarmUnitDtos);
     }
 
-    public void deleteAllAlarmOfMember(Member member){
+    public void deleteAllAlarmsOfMember(Member member){
+        alarmRepository.deleteAllBySender(member);
         alarmRepository.deleteAllByReceiver(member);
     }
 

--- a/src/main/java/sws/songpin/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/sws/songpin/domain/bookmark/repository/BookmarkRepository.java
@@ -16,4 +16,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Bookmark> findAllByMember(Member member);
     @Query("SELECT b.playlist.playlistId FROM Bookmark b WHERE b.member = :member AND b.playlist.playlistId IN :playlistIds")
     List<Long> findBookmarkedPlaylistIdsByMemberAndPlaylistIds(@Param("member") Member member, @Param("playlistIds") List<Long> playlistIds);
+    void deleteAllByMember(Member member);
 }

--- a/src/main/java/sws/songpin/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/sws/songpin/domain/bookmark/service/BookmarkService.java
@@ -76,7 +76,7 @@ public class BookmarkService {
                 .orElseThrow(() -> new CustomException(ErrorCode.BOOKMARK_NOT_FOUND));
     }
 
-    public void deleteAllBookmarkOfMember(Member member){
+    public void deleteAllBookmarksOfMember(Member member){
         bookmarkRepository.deleteAllByMember(member);
     }
 }

--- a/src/main/java/sws/songpin/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/sws/songpin/domain/bookmark/service/BookmarkService.java
@@ -75,4 +75,8 @@ public class BookmarkService {
         return bookmarkRepository.findById(bookmarkId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOOKMARK_NOT_FOUND));
     }
+
+    public void deleteAllBookmarkOfMember(Member member){
+        bookmarkRepository.deleteAllByMember(member);
+    }
 }

--- a/src/main/java/sws/songpin/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/sws/songpin/domain/follow/repository/FollowRepository.java
@@ -14,4 +14,6 @@ public interface FollowRepository extends JpaRepository<Follow,Long> {
     Long countByFollowing(Member following);
     Long countByFollower(Member follower);
     Optional<Follow> findByFollowerAndFollowing(Member follower, Member following);
+    void deleteAllByFollower(Member member);
+    void deleteAllByFollowing(Member member);
 }

--- a/src/main/java/sws/songpin/domain/follow/service/FollowService.java
+++ b/src/main/java/sws/songpin/domain/follow/service/FollowService.java
@@ -3,7 +3,6 @@ package sws.songpin.domain.follow.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sws.songpin.domain.alarm.entity.AlarmType;
 import sws.songpin.domain.alarm.service.AlarmService;
 import sws.songpin.domain.follow.dto.request.FollowAddRequestDto;
 import sws.songpin.domain.follow.dto.response.FollowAddResponseDto;
@@ -12,11 +11,11 @@ import sws.songpin.domain.follow.dto.response.FollowListResponseDto;
 import sws.songpin.domain.follow.entity.Follow;
 import sws.songpin.domain.follow.repository.FollowRepository;
 import sws.songpin.domain.member.entity.Member;
+import sws.songpin.domain.member.entity.Status;
 import sws.songpin.domain.member.service.MemberService;
 import sws.songpin.global.exception.CustomException;
 import sws.songpin.global.exception.ErrorCode;
 
-import java.text.MessageFormat;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +32,7 @@ public class FollowService {
     // 팔로우 추가
     public FollowAddResponseDto addFollow(FollowAddRequestDto followAddRequestDto){
         Member follower = memberService.getMemberById(followAddRequestDto.followerId());
-        Member following = memberService.getMemberById(followAddRequestDto.followingId());
+        Member following = memberService.getActiveMemberById(followAddRequestDto.followingId());
 
         if (!follower.equals(memberService.getCurrentMember())){ // follower가 자신이어야 함
             throw new CustomException(ErrorCode.UNAUTHORIZED_REQUEST);
@@ -60,7 +59,7 @@ public class FollowService {
 
     // 특정 사용자의 팔로잉/팔로워 목록 조회
     public FollowListResponseDto getFollowList(Long memberId, boolean isFollowingList) {
-        Member targetMember = memberService.getMemberById(memberId);
+        Member targetMember = memberService.getActiveMemberById(memberId);
         Member currentMember = memberService.getCurrentMember();
         Map<Member, Long> currentMemberFollowingCache = getMemberFollowingCache(currentMember);
         List<Follow> followList = isFollowingList ? findAllFollowingsOfMember(targetMember) : findAllFollowersOfMember(targetMember);
@@ -114,6 +113,7 @@ public class FollowService {
     public long getFollowerCount(Member member){
         return followRepository.countByFollowing(member);
     }
+
     @Transactional(readOnly = true)
     public long getFollowingCount(Member member){
         return followRepository.countByFollower(member);
@@ -126,7 +126,7 @@ public class FollowService {
     }
 
     //회원의 팔로워 및 팔로잉 모두 삭제
-    public void deleteAllFollowerAndFollowingOfMember(Member member){
+    public void deleteAllFollowsOfMember(Member member){
         followRepository.deleteAllByFollower(member);
         followRepository.deleteAllByFollowing(member);
     }

--- a/src/main/java/sws/songpin/domain/follow/service/FollowService.java
+++ b/src/main/java/sws/songpin/domain/follow/service/FollowService.java
@@ -124,4 +124,10 @@ public class FollowService {
         return followRepository.findByFollowerAndFollowing(follower,following)
                 .orElseThrow(()-> new CustomException(ErrorCode.FOLLOW_NOT_FOUND)).getFollowId();
     }
+
+    //회원의 팔로워 및 팔로잉 모두 삭제
+    public void deleteAllFollowerAndFollowingOfMember(Member member){
+        followRepository.deleteAllByFollower(member);
+        followRepository.deleteAllByFollowing(member);
+    }
 }

--- a/src/main/java/sws/songpin/domain/member/service/AuthService.java
+++ b/src/main/java/sws/songpin/domain/member/service/AuthService.java
@@ -40,7 +40,7 @@ public class AuthService {
         if (memberOptional.isPresent()) {
 
             if(memberOptional.get().getStatus().equals(Status.DELETED)){
-                throw new CustomException(ErrorCode.ALREADY_DELETED_MEMBER);
+                throw new CustomException(ErrorCode.MEMBER_STATUS_DELETED);
             }
 
             throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);

--- a/src/main/java/sws/songpin/domain/member/service/MemberService.java
+++ b/src/main/java/sws/songpin/domain/member/service/MemberService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import sws.songpin.domain.member.dto.response.MemberSearchResponseDto;
 import sws.songpin.domain.member.dto.response.MemberUnitDto;
 import sws.songpin.domain.member.entity.Member;
+import sws.songpin.domain.member.entity.Status;
 import sws.songpin.domain.member.repository.MemberRepository;
 import sws.songpin.global.exception.CustomException;
 import sws.songpin.global.exception.ErrorCode;
@@ -45,6 +46,15 @@ public class MemberService {
     public Member getMemberById(Long memberId){
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public Member getActiveMemberById(Long memberId){
+        Member member = getMemberById(memberId);
+        if (member.getStatus().equals(Status.DELETED)) {
+            throw new CustomException(ErrorCode.MEMBER_STATUS_DELETED);
+        }
+        return member;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/sws/songpin/domain/member/service/ProfileService.java
+++ b/src/main/java/sws/songpin/domain/member/service/ProfileService.java
@@ -32,17 +32,12 @@ public class ProfileService {
 
     @Transactional(readOnly = true)
     public MemberProfileResponseDto getMemberProfile(Long memberId){
-        Member member = memberService.getMemberById(memberId);
+        Member member = memberService.getActiveMemberById(memberId);
         Member currentMember = memberService.getCurrentMember();
 
         //조회하려는 회원이 본인인 경우 예외 처리
         if(member.equals(currentMember)){
             throw new CustomException(ErrorCode.MEMBER_BAD_REQUEST);
-        }
-
-        //조회하려는 회원이 탈퇴한 경우 예외 처리
-        if(member.getStatus().equals(Status.DELETED)){
-            throw new CustomException(ErrorCode.ALREADY_DELETED_MEMBER);
         }
 
         //팔로워 수
@@ -105,13 +100,13 @@ public class ProfileService {
         memberService.saveMember(member);
 
         //follow 테이블 데이터 삭제
-        followService.deleteAllFollowerAndFollowingOfMember(member);
+        followService.deleteAllFollowsOfMember(member);
 
         //bookmark 테이블 데이터 삭제
-        bookmarkService.deleteAllBookmarkOfMember(member);
+        bookmarkService.deleteAllBookmarksOfMember(member);
 
         //alarm 테이블 데이터 삭제
-        alarmService.deleteAllAlarmOfMember(member);
+        alarmService.deleteAllAlarmsOfMember(member);
 
         //Redis에서 Refresh Token 삭제
         redisService.deleteValues(member.getEmail());

--- a/src/main/java/sws/songpin/domain/member/service/ProfileService.java
+++ b/src/main/java/sws/songpin/domain/member/service/ProfileService.java
@@ -10,6 +10,7 @@ import sws.songpin.domain.member.dto.response.MemberProfileResponseDto;
 import sws.songpin.domain.member.dto.response.MyProfileResponseDto;
 import sws.songpin.domain.member.entity.Member;
 import sws.songpin.domain.member.entity.ProfileImg;
+import sws.songpin.domain.member.entity.Status;
 import sws.songpin.global.auth.RedisService;
 import sws.songpin.global.exception.CustomException;
 import sws.songpin.global.exception.ErrorCode;
@@ -30,8 +31,14 @@ public class ProfileService {
         Member member = memberService.getMemberById(memberId);
         Member currentMember = memberService.getCurrentMember();
 
+        //조회하려는 회원이 본인인 경우 예외 처리
         if(member.equals(currentMember)){
             throw new CustomException(ErrorCode.MEMBER_BAD_REQUEST);
+        }
+
+        //조회하려는 회원이 탈퇴한 경우 예외 처리
+        if(member.getStatus().equals(Status.DELETED)){
+            throw new CustomException(ErrorCode.ALREADY_DELETED_MEMBER);
         }
 
         //팔로워 수

--- a/src/main/java/sws/songpin/domain/member/service/ProfileService.java
+++ b/src/main/java/sws/songpin/domain/member/service/ProfileService.java
@@ -3,6 +3,8 @@ package sws.songpin.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sws.songpin.domain.alarm.service.AlarmService;
+import sws.songpin.domain.bookmark.service.BookmarkService;
 import sws.songpin.domain.follow.service.FollowService;
 import sws.songpin.domain.member.dto.request.ProfileDeactivateRequestDto;
 import sws.songpin.domain.member.dto.request.ProfileUpdateRequestDto;
@@ -25,6 +27,8 @@ public class ProfileService {
     private final FollowService followService;
     private final AuthService authService;
     private final RedisService redisService;
+    private final AlarmService alarmService;
+    private final BookmarkService bookmarkService;
 
     @Transactional(readOnly = true)
     public MemberProfileResponseDto getMemberProfile(Long memberId){
@@ -99,6 +103,15 @@ public class ProfileService {
         //Status, Nickname, Handle 변경
         member.deactivate(handle);
         memberService.saveMember(member);
+
+        //follow 테이블 데이터 삭제
+        followService.deleteAllFollowerAndFollowingOfMember(member);
+
+        //bookmark 테이블 데이터 삭제
+        bookmarkService.deleteAllBookmarkOfMember(member);
+
+        //alarm 테이블 데이터 삭제
+        alarmService.deleteAllAlarmOfMember(member);
 
         //Redis에서 Refresh Token 삭제
         redisService.deleteValues(member.getEmail());

--- a/src/main/java/sws/songpin/global/auth/CustomUserDetailsService.java
+++ b/src/main/java/sws/songpin/global/auth/CustomUserDetailsService.java
@@ -24,7 +24,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow(()-> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         if(member.getStatus().equals(Status.DELETED)){
-            throw new CustomException(ErrorCode.ALREADY_DELETED_MEMBER);
+            throw new CustomException(ErrorCode.MEMBER_STATUS_DELETED);
         }
 
         return new CustomUserDetails(member);

--- a/src/main/java/sws/songpin/global/exception/ErrorCode.java
+++ b/src/main/java/sws/songpin/global/exception/ErrorCode.java
@@ -38,7 +38,7 @@ public enum ErrorCode {
     // 만료된 토큰
     EXPIRED_TOKEN(401,"만료된 토큰입니다."),
     // 탈퇴한 회원
-    ALREADY_DELETED_MEMBER(401, "탈퇴한 회원입니다."),
+    MEMBER_STATUS_DELETED(401, "탈퇴한 회원입니다."),
 
     // 404 Not Found
     // 각 리소스를 찾지 못함


### PR DESCRIPTION
# 구현 기능
  - 탈퇴한 회원의 프로필을 조회하지 못하도록 처리
  - 탈퇴한 회원의 follow, alarm, bookmark 데이터 삭제

# 구현 상태
  - 탈퇴한 회원의 프로필을 조회하려고 할 때 응답
 ```json
{
  "timestamp": "2024-07-24T18:07:15.790904",
  "status": 401,
  "errorCode": "ALREADY_DELETED_MEMBER",
  "message": "탈퇴한 회원입니다.",
  "path": "/members/23"
}
```

# Resolve
  - #75 