### PR TITLE
[Refactor] map 최근 기간 기준 api에서 쓰이는 PeriodFilter ENUM 사용하도록 변경

### DIFF
--- a/src/main/java/sws/songpin/domain/place/controller/PlaceController.java
+++ b/src/main/java/sws/songpin/domain/place/controller/PlaceController.java
@@ -26,8 +26,8 @@ public class PlaceController {
     @Operation(summary = "장소 검색", description = "장소 검색 결과를 선택한 정렬 기준에 따라 페이징으로 불러옵니다.")
     @GetMapping
     public ResponseEntity<?> placeSearch(@RequestParam final String keyword,
-                                         @RequestParam(defaultValue = "ACCURACY") final String sortBy,
+                                         @RequestParam(defaultValue = "ACCURACY") final SortBy sortBy,
                                          @PageableDefault(size = 20) final Pageable pageable) {
-        return ResponseEntity.ok().body(placeService.searchPlaces(keyword, SortBy.from(sortBy), pageable));
+        return ResponseEntity.ok().body(placeService.searchPlaces(keyword, sortBy, pageable));
     }
 }

--- a/src/main/java/sws/songpin/domain/place/dto/request/MapFetchRecentPeriodRequestDto.java
+++ b/src/main/java/sws/songpin/domain/place/dto/request/MapFetchRecentPeriodRequestDto.java
@@ -2,12 +2,13 @@ package sws.songpin.domain.place.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import sws.songpin.domain.genre.entity.GenreName;
+import sws.songpin.domain.place.entity.PeriodFilter;
 
 import java.util.List;
 
 public record MapFetchRecentPeriodRequestDto(
         @NotNull MapBoundCoordsDto boundCoords,
         List<GenreName> genreNameFilters,
-        @NotNull String periodFilter // "week", "month", "threeMonths"
+        @NotNull PeriodFilter periodFilter
 ) {
 }

--- a/src/main/java/sws/songpin/domain/place/entity/PeriodFilter.java
+++ b/src/main/java/sws/songpin/domain/place/entity/PeriodFilter.java
@@ -1,0 +1,19 @@
+package sws.songpin.domain.place.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import sws.songpin.global.exception.CustomException;
+import sws.songpin.global.exception.ErrorCode;
+
+public enum PeriodFilter {
+    WEEK, MONTH, THREE_MONTHS
+    ;
+
+    @JsonCreator
+    public static PeriodFilter from(String s) {
+        try {
+            return PeriodFilter.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
+    }
+}

--- a/src/main/java/sws/songpin/domain/place/service/MapService.java
+++ b/src/main/java/sws/songpin/domain/place/service/MapService.java
@@ -15,6 +15,8 @@ import sws.songpin.domain.place.dto.request.MapFetchRecentPeriodRequestDto;
 import sws.songpin.domain.place.dto.response.MapPlaceFetchResponseDto;
 import sws.songpin.domain.place.dto.projection.MapPlaceProjectionDto;
 import sws.songpin.domain.place.repository.MapPlaceRepository;
+import sws.songpin.global.exception.CustomException;
+import sws.songpin.global.exception.ErrorCode;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -39,10 +41,10 @@ public class MapService {
         LocalDate startDate;
         LocalDate endDate = LocalDate.now();
         switch (requestDto.periodFilter()) {
-            case "week" -> startDate = endDate.minusWeeks(1);
-            case "month" -> startDate = endDate.minusMonths(1);
-            case "threeMonths"-> startDate = endDate.minusMonths(3);
-            default -> throw new IllegalArgumentException("Invalid period filter: " + requestDto.periodFilter());
+            case WEEK -> startDate = endDate.minusWeeks(1);
+            case MONTH -> startDate = endDate.minusMonths(1);
+            case THREE_MONTHS-> startDate = endDate.minusMonths(3);
+            default -> throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
         }
         List<GenreName> genreNameList =  getSelectedGenreNames(requestDto.genreNameFilters());
         Slice<MapPlaceProjectionDto> dtoSlice = getMapPlaceSlicesWithinBoundsAndDateRange(requestDto.boundCoords(), genreNameList, startDate, endDate);


### PR DESCRIPTION
# 구현 기능
  - map 최근 기간 기준 api에서 쓰이는 PeriodFilter가 ENUM을 사용하도록 변경했습니다. (`MapFetchRecentPeriodRequestDto`)
  - 기존 코드가 서버 내부에서 에러를 던지도록 해서 던지는 에러의 종류를 CustomException으로 변경해야 했는데, 이렇게 이를 통해 ENUM과 맞지 않는 값이 들어올 경우 알아서 (JsonCreator를 통해) 에러가 던져지도록 했습니다.

# Resolve
  - #93 