### PR TITLE
[Fix] SecurityConfig의 filterChain에서 requestMatchers 설정 변경

### DIFF
--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -102,9 +102,11 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtFilter(jwtUtil), LogoutFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AUTH_WHITELIST).permitAll()
-                        .requestMatchers(HttpMethod.GET,"/places/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/places/{placeId}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/places").authenticated()
+                        .requestMatchers(HttpMethod.GET,"/playlists/{playlistId}").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/playlists").authenticated()
                         .requestMatchers(HttpMethod.GET,"/playlists/main").authenticated()
-                        .requestMatchers(HttpMethod.GET,"/playlists/**").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
         ;

--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -103,10 +103,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AUTH_WHITELIST).permitAll()
                         .requestMatchers(HttpMethod.GET, "/places/{placeId}").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/places").authenticated()
-                        .requestMatchers(HttpMethod.GET,"/playlists/{playlistId}").permitAll()
-                        .requestMatchers(HttpMethod.GET,"/playlists").authenticated()
                         .requestMatchers(HttpMethod.GET,"/playlists/main").authenticated()
+                        .requestMatchers(HttpMethod.GET,"/playlists/{playlistId}").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
         ;


### PR DESCRIPTION
# 구현 기능
  - 플레이리스트 main의 접근을 authenticated()로 설정했습니다. (적어주지 않을 경우 playlistId로 인식하는 문제)
  - 장소 상세정보, 플레이리스트 상세정보의 접근을 permitAll()로 설정하였습니다.
# Resolve
  - #117 
