### PR TITLE
[Fix] Place - SortBy 대소문자 무시 위해 문자열로 받은 후 변환 진행

### DIFF
--- a/src/main/java/sws/songpin/domain/place/controller/PlaceController.java
+++ b/src/main/java/sws/songpin/domain/place/controller/PlaceController.java
@@ -26,8 +26,8 @@ public class PlaceController {
     @Operation(summary = "장소 검색", description = "장소 검색 결과를 선택한 정렬 기준에 따라 페이징으로 불러옵니다.")
     @GetMapping
     public ResponseEntity<?> placeSearch(@RequestParam final String keyword,
-                                         @RequestParam(defaultValue = "ACCURACY") final SortBy sortBy,
+                                         @RequestParam(defaultValue = "ACCURACY") final String sortBy,
                                          @PageableDefault(size = 20) final Pageable pageable) {
-        return ResponseEntity.ok().body(placeService.searchPlaces(keyword, sortBy, pageable));
+        return ResponseEntity.ok().body(placeService.searchPlaces(keyword, SortBy.from(sortBy), pageable));
     }
 }


### PR DESCRIPTION
# 구현 기능
  - PlaceController의 검색 api에서 RequestParam으로 쓰이는 SortBy의 대소문자를 무시하고자 함. 이를 위해 문자열로 받은 후 ENUM으로 변환 진행
    - (예전에 제대로 이렇게 코드를 작성했었는데, 언젠가 enum으로 받아도 되는 줄 알고 착각을 해서 잘못된 코드로 바꿨었네요...)

# Resolve
  - #121 
