### PR TITLE
[Fix] 허용되는 HTTP methods 와일드카드 대신 개별 작성

### DIFF
--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -28,6 +28,7 @@ import sws.songpin.global.auth.JwtFilter;
 import sws.songpin.global.auth.JwtUtil;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -61,11 +62,11 @@ public class SecurityConfig {
                 "https://localhost:3000",
                 "https://api.songpin.n-e.kr"));
 
-        configuration.addAllowedMethod("*");
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"));
         configuration.addAllowedHeader("*");
+        configuration.addExposedHeader("Set-Cookie");
         configuration.setAllowCredentials(true);
 
-        configuration.addExposedHeader("Set-Cookie");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -28,7 +28,6 @@ import sws.songpin.global.auth.JwtFilter;
 import sws.songpin.global.auth.JwtUtil;
 
 import java.util.Arrays;
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -62,7 +61,7 @@ public class SecurityConfig {
                 "https://localhost:3000",
                 "https://api.songpin.n-e.kr"));
 
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"));
         configuration.addAllowedHeader("*");
         configuration.addExposedHeader("Set-Cookie");
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
# 구현 기능
 - 문제 상황: 클라이언트에서 PATCH 메소드가 허용되지 않아 CORS 에러가 발생했다는 에러가 발생하여, 허용 헤더를 와일드카드를 쓰는 대신 개별적으로 작성해 보았습니다.
![image](https://github.com/user-attachments/assets/58b78cae-c4d1-4f89-ad18-ef5cdd193f9b)
  - 변경된 코드
  ```
        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"));
```

# Resolve
  - #107 