### PR TITLE
[Refactor] PlaylistService 상세정보 위주 리팩토링

### DIFF
--- a/src/main/java/sws/songpin/domain/member/controller/MemberController.java
+++ b/src/main/java/sws/songpin/domain/member/controller/MemberController.java
@@ -43,7 +43,7 @@ public class MemberController {
     @Operation(summary = "타 유저 플레이리스트 목록 조회", description = "타 유저 페이지에서 플레이리스트 목록 조회")
     @GetMapping("/{memberId}/playlists")
     public ResponseEntity<?> getAllPlaylists(@PathVariable("memberId") final Long memberId){
-        return ResponseEntity.ok(playlistService.getAllPlaylists(memberId));
+        return ResponseEntity.ok(playlistService.getAllPlaylistsOfMember(memberId));
     }
 
     @Operation(summary = "타 유저의 핀 피드 조회", description = "타 유저의 핀 피드를 조회합니다.")

--- a/src/main/java/sws/songpin/domain/member/controller/MemberController.java
+++ b/src/main/java/sws/songpin/domain/member/controller/MemberController.java
@@ -43,7 +43,7 @@ public class MemberController {
     @Operation(summary = "타 유저 플레이리스트 목록 조회", description = "타 유저 페이지에서 플레이리스트 목록 조회")
     @GetMapping("/{memberId}/playlists")
     public ResponseEntity<?> getAllPlaylists(@PathVariable("memberId") final Long memberId){
-        return ResponseEntity.ok(playlistService.getAllPlaylistsOfMember(memberId));
+        return ResponseEntity.ok(playlistService.getMemberPlaylists(memberId));
     }
 
     @Operation(summary = "타 유저의 핀 피드 조회", description = "타 유저의 핀 피드를 조회합니다.")

--- a/src/main/java/sws/songpin/domain/member/controller/MyPageController.java
+++ b/src/main/java/sws/songpin/domain/member/controller/MyPageController.java
@@ -33,7 +33,7 @@ public class MyPageController {
     @Operation(summary = "내 플레이리스트 목록 조회", description = "마이페이지에서 내 플레이리스트 목록 조회")
     @GetMapping("/playlists")
     public ResponseEntity<?> getAllPlaylists(){
-        return ResponseEntity.ok(playlistService.getAllPlaylistsOfMember());
+        return ResponseEntity.ok(playlistService.getMemberPlaylists());
     }
 
     @Operation(summary = "내 북마크 목록 조회", description = "마이페이지에서 북마크 목록 조회")

--- a/src/main/java/sws/songpin/domain/member/controller/MyPageController.java
+++ b/src/main/java/sws/songpin/domain/member/controller/MyPageController.java
@@ -33,7 +33,7 @@ public class MyPageController {
     @Operation(summary = "내 플레이리스트 목록 조회", description = "마이페이지에서 내 플레이리스트 목록 조회")
     @GetMapping("/playlists")
     public ResponseEntity<?> getAllPlaylists(){
-        return ResponseEntity.ok(playlistService.getAllPlaylists());
+        return ResponseEntity.ok(playlistService.getAllPlaylistsOfMember());
     }
 
     @Operation(summary = "내 북마크 목록 조회", description = "마이페이지에서 북마크 목록 조회")

--- a/src/main/java/sws/songpin/domain/member/service/HomeService.java
+++ b/src/main/java/sws/songpin/domain/member/service/HomeService.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sws.songpin.domain.member.dto.response.HomeResponseDto;
 import sws.songpin.domain.member.entity.Member;
-import sws.songpin.domain.member.repository.MemberRepository;
 import sws.songpin.domain.pin.dto.response.PinBasicUnitDto;
 import sws.songpin.domain.pin.entity.Pin;
 import sws.songpin.domain.pin.repository.PinRepository;
@@ -21,7 +20,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class HomeService {
     private final MemberService memberService;
-    private final MemberRepository memberRepository;
     private final PinRepository pinRepository;
     private final PlaceRepository placeRepository;
 

--- a/src/main/java/sws/songpin/domain/member/service/MemberService.java
+++ b/src/main/java/sws/songpin/domain/member/service/MemberService.java
@@ -40,7 +40,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public Member getCurrentMember() {
+    public Member getCurrentMember() throws CustomException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Member member = memberRepository.findByEmail(authentication.getName())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_AUTHENTICATED));

--- a/src/main/java/sws/songpin/domain/member/service/MemberService.java
+++ b/src/main/java/sws/songpin/domain/member/service/MemberService.java
@@ -51,6 +51,15 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
+    public Member getCurrentMemberOrNull() {
+        try {
+            return getCurrentMember();
+        } catch (CustomException e) { // 로그인하지 않은 경우
+            return null;
+        }
+    }
+
+    @Transactional(readOnly = true)
     public Member getMemberById(Long memberId){
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistPinUnitDto.java
+++ b/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistPinUnitDto.java
@@ -1,6 +1,7 @@
 package sws.songpin.domain.playlist.dto.response;
 
 import sws.songpin.domain.genre.entity.GenreName;
+import sws.songpin.domain.playlistpin.entity.PlaylistPin;
 import sws.songpin.domain.song.dto.response.SongInfoDto;
 import java.time.LocalDate;
 
@@ -13,5 +14,20 @@ public record PlaylistPinUnitDto(
         double placeLatitude,
         double placeLongitude,
         GenreName genreName,
-        int pinIndex) {
+        int pinIndex
+) {
+    public static PlaylistPinUnitDto fromEntity(PlaylistPin playlistPin) {
+        SongInfoDto songInfo = SongInfoDto.from(playlistPin.getPin().getSong());
+            return new PlaylistPinUnitDto(
+                playlistPin.getPlaylistPinId(),
+                playlistPin.getPin().getPinId(),
+                songInfo,
+                playlistPin.getPin().getListenedDate(),
+                playlistPin.getPin().getPlace().getPlaceName(),
+                playlistPin.getPin().getPlace().getLatitude(),
+                playlistPin.getPin().getPlace().getLongitude(),
+                playlistPin.getPin().getGenre().getGenreName(),
+                playlistPin.getPinIndex()
+        );
+    }
 }

--- a/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistPinUnitDto.java
+++ b/src/main/java/sws/songpin/domain/playlist/dto/response/PlaylistPinUnitDto.java
@@ -16,7 +16,7 @@ public record PlaylistPinUnitDto(
         GenreName genreName,
         int pinIndex
 ) {
-    public static PlaylistPinUnitDto fromEntity(PlaylistPin playlistPin) {
+    public static PlaylistPinUnitDto from (PlaylistPin playlistPin) {
         SongInfoDto songInfo = SongInfoDto.from(playlistPin.getPin().getSong());
             return new PlaylistPinUnitDto(
                 playlistPin.getPlaylistPinId(),

--- a/src/main/java/sws/songpin/domain/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/sws/songpin/domain/playlist/repository/PlaylistRepository.java
@@ -6,12 +6,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import sws.songpin.domain.member.entity.Member;
+import sws.songpin.domain.model.Visibility;
 import sws.songpin.domain.playlist.entity.Playlist;
 
 import java.util.List;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
     List<Playlist> findAllByCreator(Member member);
+
+    @Query("SELECT p FROM Playlist p WHERE p.creator = :creator AND p.visibility = 'PUBLIC'")
+    List<Playlist> findAllPublicByCreator(@Param("creator") Member creator);
+
 
     @Query(value = "SELECT p.playlist_id, p.playlist_name, COUNT(pin.pin_id) AS pin_count " +
             "FROM playlist p " +

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -134,15 +134,6 @@ public class PlaylistService {
         playlistRepository.delete(playlist);
     }
 
-    // Playlist를 PlaylistUnitDto로 변환
-    @Transactional(readOnly = true)
-    public PlaylistUnitDto convertToPlaylistUnitDto(Playlist playlist, Member currentMember) {
-        List<String> imgPathList = getPlaylistThumbnailImgPathList(playlist);
-        Long bookmarkId = getBookmarkIdForPlaylistAndMember(playlist, currentMember);
-        return PlaylistUnitDto.from(playlist, imgPathList, bookmarkId);
-    }
-
-
     // 내 플레이리스트 조회
     @Transactional(readOnly = true)
     public PlaylistListResponseDto getAllPlaylistsOfMember(){
@@ -170,15 +161,6 @@ public class PlaylistService {
                 .map(playlist -> convertToPlaylistUnitDto(playlist, currentMember))
                 .collect(Collectors.toList());
         return PlaylistListResponseDto.from(playlistList);
-    }
-
-    // imgPathList
-    @Transactional(readOnly = true)
-    public List<String> getPlaylistThumbnailImgPathList(Playlist playlist) {
-        return playlist.getPlaylistPins().stream()
-                .map(playlistPin -> playlistPin.getPin().getSong().getImgPath())
-                .limit(3)
-                .collect(Collectors.toList());
     }
 
     // 플레이리스트 메인 페이지 조회
@@ -231,6 +213,17 @@ public class PlaylistService {
         });
         // PlaylistSearchResponseDto를 반환
         return PlaylistSearchResponseDto.from(playlistUnitPage);
+    }
+
+    // Playlist를 PlaylistUnitDto로 변환
+    @Transactional(readOnly = true)
+    public PlaylistUnitDto convertToPlaylistUnitDto(Playlist playlist, Member currentMember) {
+        List<String> imgPathList = playlist.getPlaylistPins().stream()
+                .map(playlistPin -> playlistPin.getPin().getSong().getImgPath())
+                .limit(3)
+                .collect(Collectors.toList());
+        Long bookmarkId = getBookmarkIdForPlaylistAndMember(playlist, currentMember);
+        return PlaylistUnitDto.from(playlist, imgPathList, bookmarkId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -134,7 +134,7 @@ public class PlaylistService {
         playlistRepository.delete(playlist);
     }
 
-    // Playlist를 PlaylistUnitDto로 전환
+    // Playlist를 PlaylistUnitDto로 변환
     @Transactional(readOnly = true)
     public PlaylistUnitDto convertToPlaylistUnitDto(Playlist playlist, Member currentMember) {
         List<String> imgPathList = getPlaylistThumbnailImgPathList(playlist);

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -57,7 +57,7 @@ public class PlaylistService {
     // 플레이리스트 상세 정보 가져오기
     @Transactional(readOnly = true)
     public PlaylistDetailsResponseDto getPlaylist(Long playlistId) {
-        Member currentMember = getCurrentMemberOrNullForPlaylistDetails();
+        Member currentMember = memberService.getCurrentMemberOrNull();
         Playlist playlist = findPlaylistById(playlistId);
         // isMine
         boolean isMine = currentMember != null && currentMember.equals(playlist.getCreator());
@@ -71,7 +71,7 @@ public class PlaylistService {
         playlistPins.stream()
                 .sorted(Comparator.comparingInt(PlaylistPin::getPinIndex).reversed())
                 .forEach(playlistPin -> {
-                    pinList.add(PlaylistPinUnitDto.fromEntity(playlistPin));
+                    pinList.add(PlaylistPinUnitDto.from(playlistPin));
                     if (imgPathList.size() < 3) {
                         imgPathList.add(playlistPin.getPin().getSong().getImgPath());
                     }
@@ -231,14 +231,5 @@ public class PlaylistService {
         return bookmarkRepository.findByPlaylistAndMember(playlist, member)
                 .map(Bookmark::getBookmarkId)
                 .orElse(null);
-    }
-
-    @Transactional(readOnly = true)
-    public Member getCurrentMemberOrNullForPlaylistDetails() {
-        try {
-            return memberService.getCurrentMember();
-        } catch (CustomException e) { // 로그인하지 않은 경우
-            return null;
-        }
     }
 }

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -136,21 +136,21 @@ public class PlaylistService {
 
     // 내 플레이리스트 조회
     @Transactional(readOnly = true)
-    public PlaylistListResponseDto getAllPlaylistsOfMember(){
+    public PlaylistListResponseDto getMemberPlaylists(){
         Member currentMember = memberService.getCurrentMember();
-        return getAllPlaylistsOfMember(currentMember, currentMember);
+        return getMemberPlaylists(currentMember, currentMember);
     }
 
     // 타 유저 플레이리스트 조회
     @Transactional(readOnly = true)
-    public PlaylistListResponseDto getAllPlaylistsOfMember(Long memberId) {
+    public PlaylistListResponseDto getMemberPlaylists(Long memberId) {
         Member creator = memberService.getMemberById(memberId);
         Member currentMember = memberService.getCurrentMember();
-        return getAllPlaylistsOfMember(creator, currentMember);
+        return getMemberPlaylists(creator, currentMember);
     }
 
     @Transactional(readOnly = true)
-    public PlaylistListResponseDto getAllPlaylistsOfMember(Member creator, Member currentMember) {
+    public PlaylistListResponseDto getMemberPlaylists(Member creator, Member currentMember) {
         List<Playlist> playlists;
         if (creator.equals(currentMember)) {
             playlists = playlistRepository.findAllByCreator(creator);


### PR DESCRIPTION
# 구현 기능
### PlaylistService 위주로 코드 리팩토링
  - 특정 사용자의 플레이리스트 목록을 조회하는 메소드 이름을 getAllPlaylists() -> getMemberPlaylists()로 변경했습니다.
    - PlaylistRepository에 findAllPublicByCreator()를 따로 만들어서 사용했습니다. 
  -  플레이리스트 상세정보에 쓰이는getMemberForPlaylistDetails() -> getCurrentMemberOrNullForPlaylistDetails()로 메소드를 리네이밍하고 내부 구현 코드를 변경하였습니다.
     - try-catch 문을 사용하므로, MemberService getCurrentMember()에 CustomException을 던짐을 명시적으로 나타내 주었습니다.
  - PlaylistPinUnitDto 내부에 public static PlaylistPinUnitDto fromEntity()를 만들었습니다. 
  - Playlist를 PlaylistUnitDto로 변환시키는 코드가 많이 중복되어있어 convertToPlaylistUnitDto()로 따로 생성하고 getPlaylistThumbnailImgPathList 메소드를 삭제했습니다. (내부로 삽입)
  - Visibility 비교 때문에 ENUM 비교에 대해 검색해보았는데 ==를 equals()보다 지향하는 것 같아 (NPE 발생하지 않음으로) 이렇게 바꾸었습니다.
  - 사용되지 않는 필드주입들을 삭제했습니다. 