### PR TITLE
[Feat] 닉네임 제약 조건 변경 및 에러 메시지 수정

### DIFF
--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
@@ -6,8 +6,7 @@ import jakarta.validation.constraints.Size;
 public record PasswordResetRequestDto(
         @NotBlank
         String uuid,
-        @Size(min = 8, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상이어야 합니다.")
-        @Size(max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 20자 이내여야 합니다.")
+        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내만 허용됩니다.")
         @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
         String password,
         String confirmPassword

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
@@ -4,8 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record PasswordUpdateRequestDto(
-        @Size(min = 8, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상이어야 합니다.")
-        @Size(max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 20자 이내여야 합니다.")
+        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내만 허용됩니다.")
         @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
         String password,
         String confirmPassword

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 public record ProfileUpdateRequestDto (
         @NotBlank
         String profileImg,
-        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다. 공백은 허용되지 않습니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         @NotBlank
         String nickname,

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
@@ -13,8 +13,7 @@ public record ProfileUpdateRequestDto (
         String nickname,
         @NotBlank
         @Pattern(regexp = "^[a-z0-9_]+$", message = "INVALID_INPUT_FORMAT-핸들은 영어 소문자, 숫자, 언더바(_) 조합만 허용됩니다.")
-        @Size(min = 3, message = "INVALID_INPUT_LENGTH-핸들은 최소 3자 이상이어야 합니다.")
-        @Size(max = 12, message = "INVALID_INPUT_LENGTH-핸들은 12자 이내여야 합니다.")
+        @Size(min = 3, max = 12, message = "INVALID_INPUT_LENGTH-핸들은 최소 3자 이상, 12자 이내만 허용됩니다.")
         String handle
 ){
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 public record ProfileUpdateRequestDto (
         @NotBlank
         String profileImg,
-        @Pattern(regexp = "^(?!.*\\s$)(?!^\\s)[가-힣a-zA-Z0-9\\s]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자, 공백 조합만 허용됩니다. 단, 공백만으로 구성되거나 공백이 맨 앞과 맨 뒤에 올 수 없습니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다. 공백은 허용되지 않습니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         @NotBlank
         String nickname,

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -10,8 +10,7 @@ public record SignUpRequestDto(
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다. 공백은 허용되지 않습니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         String nickname,
-        @Size(min = 8, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상이어야 합니다.")
-        @Size(max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 20자 이내여야 합니다.")
+        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내만 허용됩니다.")
         @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
         String password,
         String confirmPassword) {

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -7,7 +7,7 @@ public record SignUpRequestDto(
         @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
         @Size(max = 50, message = "INVALID_INPUT_LENGTH-이메일은 50자 이내여야 합니다.")
         String email,
-        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다. 공백은 허용되지 않습니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         String nickname,
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내만 허용됩니다.")

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -7,7 +7,7 @@ public record SignUpRequestDto(
         @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
         @Size(max = 50, message = "INVALID_INPUT_LENGTH-이메일은 50자 이내여야 합니다.")
         String email,
-        @Pattern(regexp = "^(?!.*\\s$)(?!^\\s)[가-힣a-zA-Z0-9\\s]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자, 공백 조합만 허용됩니다. 단, 공백만으로 구성되거나 공백이 맨 앞과 맨 뒤에 올 수 없습니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다. 공백은 허용되지 않습니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         String nickname,
         @Size(min = 8, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상이어야 합니다.")

--- a/src/main/java/sws/songpin/global/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/sws/songpin/global/auth/JwtAuthenticationEntryPoint.java
@@ -19,13 +19,13 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         Object exception = request.getAttribute("exception");
         if(exception instanceof  ErrorCode){
             ErrorCode errorCode = (ErrorCode) exception;
-            setResponse(response,errorCode);
+            setResponse(request, response,errorCode);
             return;
         }
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
     }
 
-    private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException{
+    private void setResponse(HttpServletRequest request, HttpServletResponse response, ErrorCode errorCode) throws IOException{
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         JSONObject jsonObject = new JSONObject();
@@ -33,6 +33,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         jsonObject.put("status",errorCode.getStatus());
         jsonObject.put("errorCode", errorCode.name());
         jsonObject.put("message", errorCode.getMessage());
+        jsonObject.put("path", request.getRequestURI());
         response.getWriter().println(jsonObject);
 
     }

--- a/src/main/java/sws/songpin/global/exception/ErrorCode.java
+++ b/src/main/java/sws/songpin/global/exception/ErrorCode.java
@@ -65,7 +65,7 @@ public enum ErrorCode {
     FOLLOW_ALREADY_EXISTS(409, "이미 팔로우하고 있습니다."),
     BOOKMARK_ALREADY_EXISTS(409, "이미 북마크가 되어있습니다."),
     PLAYLIST_PIN_ALREADY_EXISTS(409, "이미 플레이리스트에 추가된 핀입니다."),
-    HANDLE_ALREADY_EXISTS(409,"이미 존재하는 핸들입니다."),
+    HANDLE_ALREADY_EXISTS(409,"이미 다른 사람이 사용 중인 핸들명입니다."),
 
     // 500 Internal Server Error
     // 외부 API 사용 도중 에러

--- a/src/main/java/sws/songpin/global/exception/ErrorCode.java
+++ b/src/main/java/sws/songpin/global/exception/ErrorCode.java
@@ -65,7 +65,7 @@ public enum ErrorCode {
     FOLLOW_ALREADY_EXISTS(409, "이미 팔로우하고 있습니다."),
     BOOKMARK_ALREADY_EXISTS(409, "이미 북마크가 되어있습니다."),
     PLAYLIST_PIN_ALREADY_EXISTS(409, "이미 플레이리스트에 추가된 핀입니다."),
-    HANDLE_ALREADY_EXISTS(409,"이미 다른 사람이 사용 중인 핸들명입니다."),
+    HANDLE_ALREADY_EXISTS(409,"이미 다른 사람이 사용 중인 핸들입니다."),
 
     // 500 Internal Server Error
     // 외부 API 사용 도중 에러


### PR DESCRIPTION
# 구현 기능
  - 회원가입/프로필 편집 API: 닉네임에 공백을 포함하는 것이 불가능하도록 요청 DTO 수정
  - 핸들 중복 에러 메시지 수정 (`이미 다른 사람이 사용 중인 핸들입니다.`)
  - JWT 토큰 검증 관련 에러 응답이 ErrorDto 와 동일한 형식을 갖도록 수정


# Resolve
  - #121
