### PR TITLE
[Fix] Auth, Member - 요청 Dto의 유효성 체크 오류 수정, NotEmpty 추가

### DIFF
--- a/src/main/java/sws/songpin/domain/member/dto/request/EmailRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/EmailRequestDto.java
@@ -1,9 +1,11 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
 
 public record EmailRequestDto(
         @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-이메일을 입력하세요.")
         String email
 ) {
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/LoginRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/LoginRequestDto.java
@@ -1,12 +1,12 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 public record LoginRequestDto(
         @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
-        @NotBlank
+        @NotEmpty(message = "INVALID_INPUT_VALUE-이메일을 입력하세요.")
         String email,
-        @NotBlank
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password
 ) { }

--- a/src/main/java/sws/songpin/domain/member/dto/request/MemberRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/MemberRequestDto.java
@@ -1,4 +1,0 @@
-package sws.songpin.domain.member.dto.request;
-
-public record MemberRequestDto() {
-}

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
@@ -1,14 +1,16 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
 public record PasswordResetRequestDto(
         @NotBlank
         String uuid,
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호 확인을 입력하세요.")
         String confirmPassword
 ) {
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
@@ -2,11 +2,13 @@ package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record PasswordResetRequestDto(
         @NotBlank
         String uuid,
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()]+$", message = "INVALID_INPUT_FORMAT-비밀번호는 영문 대소문자, 숫자, 특수문자 !@#$%^&*()만 사용 가능합니다.")
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
@@ -6,8 +6,8 @@ import jakarta.validation.constraints.Size;
 public record PasswordResetRequestDto(
         @NotBlank
         String uuid,
-        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내만 허용됩니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
+        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
+        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
         String confirmPassword
 ) {

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
@@ -1,12 +1,13 @@
 package sws.songpin.domain.member.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
 public record PasswordUpdateRequestDto(
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호 확인을 입력하세요.")
         String confirmPassword
 ) {
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
@@ -1,9 +1,11 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record PasswordUpdateRequestDto(
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()]+$", message = "INVALID_INPUT_FORMAT-비밀번호는 영문 대소문자, 숫자, 특수문자 !@#$%^&*()만 사용 가능합니다.")
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record PasswordUpdateRequestDto(
-        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내만 허용됩니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
+        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
+        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
         String confirmPassword
 ) {

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileDeactivateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileDeactivateRequestDto.java
@@ -3,7 +3,7 @@ package sws.songpin.domain.member.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record ProfileDeactivateRequestDto(
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
+        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password
 ) {
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileDeactivateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileDeactivateRequestDto.java
@@ -1,9 +1,9 @@
 package sws.songpin.domain.member.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 public record ProfileDeactivateRequestDto(
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password
 ) {
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
@@ -10,11 +10,11 @@ public record ProfileUpdateRequestDto (
         String profileImg,
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
-        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임은 비워둘 수 없습니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임을 입력하세요.")
         String nickname,
         @Pattern(regexp = "^[a-z0-9_]+$", message = "INVALID_INPUT_FORMAT-핸들은 영문 소문자, 숫자, 언더바(_)만 사용 가능합니다.")
         @Size(min = 3, max = 12, message = "INVALID_INPUT_LENGTH-핸들은 최소 3자 이상, 12자 이내여야 합니다.")
-        @NotEmpty(message = "INVALID_INPUT_VALUE-핸들은 비워둘 수 없습니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-핸들을 입력하세요.")
         String handle
 ){
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
@@ -7,13 +7,11 @@ import jakarta.validation.constraints.Size;
 public record ProfileUpdateRequestDto (
         @NotBlank
         String profileImg,
-        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
-        @NotBlank
         String nickname,
-        @NotBlank
-        @Pattern(regexp = "^[a-z0-9_]+$", message = "INVALID_INPUT_FORMAT-핸들은 영어 소문자, 숫자, 언더바(_) 조합만 허용됩니다.")
-        @Size(min = 3, max = 12, message = "INVALID_INPUT_LENGTH-핸들은 최소 3자 이상, 12자 이내만 허용됩니다.")
+        @Pattern(regexp = "^[a-z0-9_]+$", message = "INVALID_INPUT_FORMAT-핸들은 영문 소문자, 숫자, 언더바(_)만 사용 가능합니다.")
+        @Size(min = 3, max = 12, message = "INVALID_INPUT_LENGTH-핸들은 최소 3자 이상, 12자 이내여야 합니다.")
         String handle
 ){
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -9,9 +10,11 @@ public record ProfileUpdateRequestDto (
         String profileImg,
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임은 비워둘 수 없습니다.")
         String nickname,
         @Pattern(regexp = "^[a-z0-9_]+$", message = "INVALID_INPUT_FORMAT-핸들은 영문 소문자, 숫자, 언더바(_)만 사용 가능합니다.")
         @Size(min = 3, max = 12, message = "INVALID_INPUT_LENGTH-핸들은 최소 3자 이상, 12자 이내여야 합니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-핸들은 비워둘 수 없습니다.")
         String handle
 ){
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -12,6 +12,7 @@ public record SignUpRequestDto(
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임을 입력하세요.")
         String nickname,
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()]+$", message = "INVALID_INPUT_FORMAT-비밀번호는 영문 대소문자, 숫자, 특수문자 !@#$%^&*()만 사용 가능합니다.")
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -10,7 +10,7 @@ public record SignUpRequestDto(
         String email,
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
-        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임은 비워둘 수 없습니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임을 입력하세요.")
         String nickname,
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -7,11 +7,11 @@ public record SignUpRequestDto(
         @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
         @Size(max = 50, message = "INVALID_INPUT_LENGTH-이메일은 50자 이내여야 합니다.")
         String email,
-        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         String nickname,
-        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내만 허용됩니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
+        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
+        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
         String confirmPassword) {
     public Member toEntity(String handle, String encodedPassword){

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -6,13 +6,16 @@ import sws.songpin.domain.member.entity.Member;
 public record SignUpRequestDto(
         @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
         @Size(max = 50, message = "INVALID_INPUT_LENGTH-이메일은 50자 이내여야 합니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-이메일을 입력하세요.")
         String email,
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임은 비워둘 수 없습니다.")
         String nickname,
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호 확인을 입력하세요.")
         String confirmPassword) {
     public Member toEntity(String handle, String encodedPassword){
         return Member.builder()


### PR DESCRIPTION
# 구현 기능
  - 비밀번호에 스페이스바를 입력했을 때 NotBlank 조건으로 인해 비밀번호를 입력하지 않음으로 간주되는 문제를 발견하여 -> NotEmpty로 변경했습니다. (캡쳐 이미지는 issue에 첨부)
  - null 들어왔을 경우 NPE가 발생함을 발견해, 안정성 위해 최소 NotNull을 다는 것이 좋겠다고 생각되었습니다.
    - Member RequestDto들에서 사용자 입력이 모두 String이고, 클라이언트에서 "" 가 요청될 수 있어 NotEmpty 조건을 걸었습니다.
  - 유효성 조건 미충족 시 에러 메시지를 수정했습니다.
### PR 피드백 이후 추가한 사항
  - 비밀번호 사용 가능 문자 제약조건을 추가했습니다.
    `@Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()]+$", message = "INVALID_INPUT_FORMAT-비밀번호는 영문 대소문자, 숫자, 특수문자 !@#$%^&*()만 사용 가능합니다.")`
# Resolve
  - #130