### PR TITLE
[Deploy] 배포 v0.4.8 - 내 핀 검색에 장소명도 검색 범위에 추가, Auth 유효성 검사 변경, Spotify market설정

### DIFF
--- a/src/main/java/sws/songpin/domain/member/dto/request/EmailRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/EmailRequestDto.java
@@ -1,9 +1,11 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
 
 public record EmailRequestDto(
         @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-이메일을 입력하세요.")
         String email
 ) {
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/LoginRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/LoginRequestDto.java
@@ -1,12 +1,12 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 public record LoginRequestDto(
         @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
-        @NotBlank
+        @NotEmpty(message = "INVALID_INPUT_VALUE-이메일을 입력하세요.")
         String email,
-        @NotBlank
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password
 ) { }

--- a/src/main/java/sws/songpin/domain/member/dto/request/MemberRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/MemberRequestDto.java
@@ -1,4 +1,0 @@
-package sws.songpin.domain.member.dto.request;
-
-public record MemberRequestDto() {
-}

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
@@ -1,14 +1,16 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
 public record PasswordResetRequestDto(
         @NotBlank
         String uuid,
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호 확인을 입력하세요.")
         String confirmPassword
 ) {
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
@@ -2,11 +2,13 @@ package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record PasswordResetRequestDto(
         @NotBlank
         String uuid,
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()]+$", message = "INVALID_INPUT_FORMAT-비밀번호는 영문 대소문자, 숫자, 특수문자 !@#$%^&*()만 사용 가능합니다.")
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordResetRequestDto.java
@@ -6,8 +6,8 @@ import jakarta.validation.constraints.Size;
 public record PasswordResetRequestDto(
         @NotBlank
         String uuid,
-        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내만 허용됩니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
+        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
+        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
         String confirmPassword
 ) {

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
@@ -1,12 +1,13 @@
 package sws.songpin.domain.member.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
 public record PasswordUpdateRequestDto(
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호 확인을 입력하세요.")
         String confirmPassword
 ) {
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
@@ -1,9 +1,11 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record PasswordUpdateRequestDto(
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()]+$", message = "INVALID_INPUT_FORMAT-비밀번호는 영문 대소문자, 숫자, 특수문자 !@#$%^&*()만 사용 가능합니다.")
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,

--- a/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/PasswordUpdateRequestDto.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record PasswordUpdateRequestDto(
-        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내만 허용됩니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
+        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
+        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
         String confirmPassword
 ) {

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileDeactivateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileDeactivateRequestDto.java
@@ -3,7 +3,7 @@ package sws.songpin.domain.member.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record ProfileDeactivateRequestDto(
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
+        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password
 ) {
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileDeactivateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileDeactivateRequestDto.java
@@ -1,9 +1,9 @@
 package sws.songpin.domain.member.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 public record ProfileDeactivateRequestDto(
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password
 ) {
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
@@ -10,11 +10,11 @@ public record ProfileUpdateRequestDto (
         String profileImg,
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
-        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임은 비워둘 수 없습니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임을 입력하세요.")
         String nickname,
         @Pattern(regexp = "^[a-z0-9_]+$", message = "INVALID_INPUT_FORMAT-핸들은 영문 소문자, 숫자, 언더바(_)만 사용 가능합니다.")
         @Size(min = 3, max = 12, message = "INVALID_INPUT_LENGTH-핸들은 최소 3자 이상, 12자 이내여야 합니다.")
-        @NotEmpty(message = "INVALID_INPUT_VALUE-핸들은 비워둘 수 없습니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-핸들을 입력하세요.")
         String handle
 ){
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
@@ -7,13 +7,11 @@ import jakarta.validation.constraints.Size;
 public record ProfileUpdateRequestDto (
         @NotBlank
         String profileImg,
-        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
-        @NotBlank
         String nickname,
-        @NotBlank
-        @Pattern(regexp = "^[a-z0-9_]+$", message = "INVALID_INPUT_FORMAT-핸들은 영어 소문자, 숫자, 언더바(_) 조합만 허용됩니다.")
-        @Size(min = 3, max = 12, message = "INVALID_INPUT_LENGTH-핸들은 최소 3자 이상, 12자 이내만 허용됩니다.")
+        @Pattern(regexp = "^[a-z0-9_]+$", message = "INVALID_INPUT_FORMAT-핸들은 영문 소문자, 숫자, 언더바(_)만 사용 가능합니다.")
+        @Size(min = 3, max = 12, message = "INVALID_INPUT_LENGTH-핸들은 최소 3자 이상, 12자 이내여야 합니다.")
         String handle
 ){
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/ProfileUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package sws.songpin.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -9,9 +10,11 @@ public record ProfileUpdateRequestDto (
         String profileImg,
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임은 비워둘 수 없습니다.")
         String nickname,
         @Pattern(regexp = "^[a-z0-9_]+$", message = "INVALID_INPUT_FORMAT-핸들은 영문 소문자, 숫자, 언더바(_)만 사용 가능합니다.")
         @Size(min = 3, max = 12, message = "INVALID_INPUT_LENGTH-핸들은 최소 3자 이상, 12자 이내여야 합니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-핸들은 비워둘 수 없습니다.")
         String handle
 ){
 }

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -12,6 +12,7 @@ public record SignUpRequestDto(
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임을 입력하세요.")
         String nickname,
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()]+$", message = "INVALID_INPUT_FORMAT-비밀번호는 영문 대소문자, 숫자, 특수문자 !@#$%^&*()만 사용 가능합니다.")
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -10,7 +10,7 @@ public record SignUpRequestDto(
         String email,
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
-        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임은 비워둘 수 없습니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임을 입력하세요.")
         String nickname,
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -7,11 +7,11 @@ public record SignUpRequestDto(
         @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
         @Size(max = 50, message = "INVALID_INPUT_LENGTH-이메일은 50자 이내여야 합니다.")
         String email,
-        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글 문자, 영어 대소문자, 숫자만 허용됩니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
         String nickname,
-        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내만 허용됩니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호는 한 글자 이상 입력해야 합니다.")
+        @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
+        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
         String confirmPassword) {
     public Member toEntity(String handle, String encodedPassword){

--- a/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/SignUpRequestDto.java
@@ -6,13 +6,16 @@ import sws.songpin.domain.member.entity.Member;
 public record SignUpRequestDto(
         @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
         @Size(max = 50, message = "INVALID_INPUT_LENGTH-이메일은 50자 이내여야 합니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-이메일을 입력하세요.")
         String email,
         @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "INVALID_INPUT_FORMAT-닉네임은 한글, 영문 대소문자, 숫자만 사용 가능합니다.")
         @Size(max = 8, message = "INVALID_INPUT_LENGTH-닉네임은 8자 이내여야 합니다.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-닉네임은 비워둘 수 없습니다.")
         String nickname,
         @Size(min = 8, max = 20, message = "INVALID_INPUT_LENGTH-비밀번호는 최소 8자 이상, 20자 이내여야 합니다.")
-        @NotBlank(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")
         String password,
+        @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호 확인을 입력하세요.")
         String confirmPassword) {
     public Member toEntity(String handle, String encodedPassword){
         return Member.builder()

--- a/src/main/java/sws/songpin/domain/pin/repository/PinRepository.java
+++ b/src/main/java/sws/songpin/domain/pin/repository/PinRepository.java
@@ -45,13 +45,14 @@ public interface PinRepository extends JpaRepository <Pin, Long> {
             "LEFT JOIN song s ON p.song_id = s.song_id " +
             "LEFT JOIN place pl ON p.place_id = pl.place_id " +
             "LEFT JOIN genre g ON p.genre_id = g.genre_id " +
-            "WHERE (REPLACE(s.title, ' ', '') LIKE %:keywordNoSpaces% OR REPLACE(s.artist, ' ', '') LIKE %:keywordNoSpaces%) " +
+            "WHERE (REPLACE(s.title, ' ', '') LIKE %:keywordNoSpaces% OR REPLACE(s.artist, ' ', '') LIKE %:keywordNoSpaces% OR REPLACE(pl.place_name, ' ', '') LIKE %:keywordNoSpaces%) " +
             "AND p.creator_id = :currentMemberId " +
             "GROUP BY p.pin_id " +
             "ORDER BY " +
             "CASE " +
             "WHEN REPLACE(s.title, ' ', '') LIKE :keywordNoSpaces THEN 1 " +
-            "WHEN REPLACE(s.artist, ' ', '') LIKE :keywordNoSpaces THEN 2 " +
+            "WHEN REPLACE(pl.place_name, ' ', '') LIKE :keywordNoSpaces THEN 2 " +
+            "WHEN REPLACE(s.artist, ' ', '') LIKE :keywordNoSpaces THEN 3 " +
             "END",
             countQuery = "SELECT COUNT(p.pin_id) " +
                     "FROM pin p " +

--- a/src/main/java/sws/songpin/domain/pin/repository/PinRepository.java
+++ b/src/main/java/sws/songpin/domain/pin/repository/PinRepository.java
@@ -60,6 +60,6 @@ public interface PinRepository extends JpaRepository <Pin, Long> {
                     "WHERE (REPLACE(s.title, ' ', '') LIKE %:keywordNoSpaces% OR REPLACE(s.artist, ' ', '') LIKE %:keywordNoSpaces%) " +
                     "AND p.creator_id = :currentMemberId",
             nativeQuery = true)
-    Page<Object[]> findAllBySongNameOrArtistContainingIgnoreSpaces(@Param("currentMemberId") Long currentMemberId, @Param("keywordNoSpaces") String keywordNoSpaces, Pageable pageable);
+    Page<Object[]> findAllBySongNameOrArtistOrPlaceNameContainingIgnoreSpaces(@Param("currentMemberId") Long currentMemberId, @Param("keywordNoSpaces") String keywordNoSpaces, Pageable pageable);
 
 }

--- a/src/main/java/sws/songpin/domain/pin/service/PinService.java
+++ b/src/main/java/sws/songpin/domain/pin/service/PinService.java
@@ -212,7 +212,7 @@ public class PinService {
         Member currentMember = memberService.getCurrentMember();
         Long currentMemberId = currentMember.getMemberId();
         String keywordNoSpaces = keyword.replace(" ", "");
-        Page<Object[]> myPinPage = pinRepository.findAllBySongNameOrArtistContainingIgnoreSpaces(currentMemberId, keywordNoSpaces, pageable);
+        Page<Object[]> myPinPage = pinRepository.findAllBySongNameOrArtistOrPlaceNameContainingIgnoreSpaces(currentMemberId, keywordNoSpaces, pageable);
 
         Page<PinBasicUnitDto> myPinUnitPage = myPinPage.map(objects -> {
             Long pinId = ((Number) objects[0]).longValue();

--- a/src/main/java/sws/songpin/domain/song/spotify/SpotifyUtil.java
+++ b/src/main/java/sws/songpin/domain/song/spotify/SpotifyUtil.java
@@ -1,5 +1,6 @@
 package sws.songpin.domain.song.spotify;
 
+import com.neovisionaries.i18n.CountryCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import se.michaelthelin.spotify.SpotifyApi;
@@ -44,6 +45,7 @@ public class SpotifyUtil {
         SearchTracksRequest searchTracksRequest = spotifyApi.searchTracks(query)
                 .limit(LIMIT)
                 .offset(offset)
+                .market(CountryCode.KR)
                 .build();
 
         try {


### PR DESCRIPTION
# 구현 기능
  - PR 129, 131, 134 적용 배포
> 1. 내 핀 검색에 장소명도 검색 범위에 추가
> 2. Auth, Member에서 요청 Dto에 유효성 검사 변경 (NotEmpty, 비밀번호 조건 추가 등)
> 3. 서버측에서 Spotify에 곡 검색 요청시 market(KR)을 지정하여 한국 market 에서 서비스되는 콘텐츠만 반환하도록 함 (즉, 한국 곡 많이 나오도록 설정) // API가 변경된 것은 아님
  - #129
  - #131
  - #134 

# Resolve
  - #107
  - #128
  - #130
