### PR TITLE
[Feat] Auth 관련 에러 코드에 파라미터 추가, 플레이리스트 담기 에러메시지 변경

### DIFF
--- a/src/main/java/sws/songpin/global/exception/ErrorCode.java
+++ b/src/main/java/sws/songpin/global/exception/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(400, "입력값이 잘못되었습니다."),
     MISSING_PARAMETER(400, "필수 파라미터가 누락되었습니다."),
     // 비밀번호, 비밀번호 확인이 서로 불일치
-    PASSWORD_MISMATCH(400, "비밀번호가 일치하지 않습니다."),
+    PASSWORD_MISMATCH(400, "confirmPassword:비밀번호가 일치하지 않습니다."),
     // enum 값이 잘못됨 (Visibility, GenreName, SortBy)
     INVALID_ENUM_VALUE(400, "enum 값이 잘못되었습니다."),
     // 자신과 관련해 불가능한 요청
@@ -40,7 +40,6 @@ public enum ErrorCode {
     EXPIRED_REFRESH_TOKEN(401, "만료된 리프레시 토큰입니다."),
     // 탈퇴한 회원
     MEMBER_STATUS_DELETED(401, "탈퇴한 회원입니다."),
-    ALREADY_DELETED_MEMBER(401, "탈퇴한 회원입니다."),
     // 어세스 토큰이 만료되지 않은 상황에서 재발급받으려는 경우
     ACCESS_TOKEN_NOT_EXPIRED(401,"액세스 토큰이 아직 만료되지 않았습니다."),
     // 쿠키에 리프레시 토큰이 들어있지 않은 경우
@@ -61,11 +60,11 @@ public enum ErrorCode {
 
     // 409 Conflict
     // 중복 리소스 생성 시도
-    EMAIL_ALREADY_EXISTS(409, "이미 가입된 이메일입니다."),
+    EMAIL_ALREADY_EXISTS(409, "email:이미 가입된 이메일입니다."),
+    HANDLE_ALREADY_EXISTS(409,"handle:이미 다른 사람이 사용 중인 핸들입니다."),
     FOLLOW_ALREADY_EXISTS(409, "이미 팔로우하고 있습니다."),
     BOOKMARK_ALREADY_EXISTS(409, "이미 북마크가 되어있습니다."),
-    PLAYLIST_PIN_ALREADY_EXISTS(409, "이미 플레이리스트에 추가된 핀입니다."),
-    HANDLE_ALREADY_EXISTS(409,"이미 다른 사람이 사용 중인 핸들입니다."),
+    PLAYLIST_PIN_ALREADY_EXISTS(409, "이미 담겨 있습니다."),
 
     // 500 Internal Server Error
     // 외부 API 사용 도중 에러

--- a/src/main/java/sws/songpin/global/exception/ErrorCode.java
+++ b/src/main/java/sws/songpin/global/exception/ErrorCode.java
@@ -64,7 +64,7 @@ public enum ErrorCode {
     HANDLE_ALREADY_EXISTS(409,"handle:이미 다른 사람이 사용 중인 핸들입니다."),
     FOLLOW_ALREADY_EXISTS(409, "이미 팔로우하고 있습니다."),
     BOOKMARK_ALREADY_EXISTS(409, "이미 북마크가 되어있습니다."),
-    PLAYLIST_PIN_ALREADY_EXISTS(409, "이미 담겨 있습니다."),
+    PLAYLIST_PIN_ALREADY_EXISTS(409, "이미 해당 핀이 담겨 있습니다."),
 
     // 500 Internal Server Error
     // 외부 API 사용 도중 에러


### PR DESCRIPTION
# 구현 기능
  -  Auth 관련 에러 코드에 파라미터를 추가했습니다.
  - 플레이리스트 담기 에러메시지를 변경했습니다.
    - 기존에는 `이미 플레이리스트에 추가된 핀입니다.` 였는데 "추가" 대신 "담기"라는 단어를 사용하게 되어 메시지를 변경해야 했습니다 
    - 핀이 아니라 플레이리스트를 선택하는 창에서 뜨는 메시지이므로 ~핀입니다 대신 `이미 담겨 있습니다.`로 변경하는 게 자연스러울 것으로 생각합니다.

# Resolve
  - 이슈 태그(ex: #7)
