### PR TITLE
[Fix] LoginRequestDto에서 @Email검사 삭제

### DIFF
--- a/src/main/java/sws/songpin/domain/member/dto/request/LoginRequestDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/request/LoginRequestDto.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 
 public record LoginRequestDto(
-        @Email(message = "INVALID_INPUT_FORMAT-유효한 이메일 형식이 아닙니다.")
         @NotEmpty(message = "INVALID_INPUT_VALUE-이메일을 입력하세요.")
         String email,
         @NotEmpty(message = "INVALID_INPUT_VALUE-비밀번호를 입력하세요.")


### PR DESCRIPTION
# 구현 기능
  - 로그인 시에 사용되는 LoginRequestDto의 email에서 @Email 애노테이션을 제거하여, 이메일 형식 검사를 진행하는 대신 서비스 로직을 통해 LOGIN_FAIL 에러가 반환되도록 했습니다.

# Resolve
  - #137
