### PR TITLE
[Fix] OrderBy PinId DESC 추가, avgGenreName 업데이트 시점 추가, 음악핀 정보 조회 기능 추가

### DIFF
--- a/src/main/java/sws/songpin/domain/pin/controller/PinController.java
+++ b/src/main/java/sws/songpin/domain/pin/controller/PinController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sws.songpin.domain.pin.dto.request.PinAddRequestDto;
 import sws.songpin.domain.pin.dto.request.PinUpdateRequestDto;
+import sws.songpin.domain.pin.dto.response.PinExistingInfoResponseDto;
+import sws.songpin.domain.pin.entity.Pin;
 import sws.songpin.domain.pin.service.PinService;
 import sws.songpin.domain.song.dto.response.SongDetailsResponseDto;
 
@@ -29,6 +31,14 @@ public class PinController {
         Long songId = pinService.createPin(pinAddRequestDto);
         URI location = URI.create("/songs/" + songId);
         return ResponseEntity.created(location).build();
+    }
+
+    @GetMapping("/{pinId}")
+    @Operation(summary = "핀 조회", description = "수정 전, 특정 핀의 기존 정보를 조회합니다.")
+    public ResponseEntity<?> getPin(@PathVariable("pinId") final Long pinId){
+        Pin pin = pinService.getPinById(pinId);
+        PinExistingInfoResponseDto pinExistingInfoResponseDto = PinExistingInfoResponseDto.from(pin);
+        return ResponseEntity.ok(pinExistingInfoResponseDto);
     }
 
     @PutMapping("/{pinId}")

--- a/src/main/java/sws/songpin/domain/pin/controller/PinController.java
+++ b/src/main/java/sws/songpin/domain/pin/controller/PinController.java
@@ -36,8 +36,7 @@ public class PinController {
     @GetMapping("/{pinId}")
     @Operation(summary = "핀 조회", description = "수정 전, 특정 핀의 기존 정보를 조회합니다.")
     public ResponseEntity<?> getPin(@PathVariable("pinId") final Long pinId){
-        Pin pin = pinService.getPinById(pinId);
-        PinExistingInfoResponseDto pinExistingInfoResponseDto = PinExistingInfoResponseDto.from(pin);
+        PinExistingInfoResponseDto pinExistingInfoResponseDto = pinService.getPinInfo(pinId);
         return ResponseEntity.ok(pinExistingInfoResponseDto);
     }
 

--- a/src/main/java/sws/songpin/domain/pin/dto/response/PinExistingInfoResponseDto.java
+++ b/src/main/java/sws/songpin/domain/pin/dto/response/PinExistingInfoResponseDto.java
@@ -8,8 +8,8 @@ import java.time.LocalDate;
 
 public record PinExistingInfoResponseDto(
         String songImgPath,
-        String songTitle,
-        String songArtist,
+        String title,
+        String artist,
         LocalDate listenedDate,
         String placeName,
         GenreName genreName,

--- a/src/main/java/sws/songpin/domain/pin/dto/response/PinExistingInfoResponseDto.java
+++ b/src/main/java/sws/songpin/domain/pin/dto/response/PinExistingInfoResponseDto.java
@@ -1,0 +1,31 @@
+package sws.songpin.domain.pin.dto.response;
+
+import sws.songpin.domain.genre.entity.GenreName;
+import sws.songpin.domain.model.Visibility;
+import sws.songpin.domain.pin.entity.Pin;
+
+import java.time.LocalDate;
+
+public record PinExistingInfoResponseDto(
+        String songImgPath,
+        String songTitle,
+        String songArtist,
+        LocalDate listenedDate,
+        String placeName,
+        GenreName genreName,
+        String memo,
+        Visibility visibility
+) {
+    public static PinExistingInfoResponseDto from(Pin pin) {
+        return new PinExistingInfoResponseDto(
+                pin.getSong().getImgPath(),
+                pin.getSong().getTitle(),
+                pin.getSong().getArtist(),
+                pin.getListenedDate(),
+                pin.getPlace().getPlaceName(),
+                pin.getGenre().getGenreName(),
+                pin.getMemo(),
+                pin.getVisibility()
+        );
+    }
+}

--- a/src/main/java/sws/songpin/domain/pin/dto/response/PinExistingInfoResponseDto.java
+++ b/src/main/java/sws/songpin/domain/pin/dto/response/PinExistingInfoResponseDto.java
@@ -8,8 +8,8 @@ import java.time.LocalDate;
 
 public record PinExistingInfoResponseDto(
         String songImgPath,
-        String title,
-        String artist,
+        String songTitle,
+        String songArtist,
         LocalDate listenedDate,
         String placeName,
         GenreName genreName,

--- a/src/main/java/sws/songpin/domain/pin/repository/PinRepository.java
+++ b/src/main/java/sws/songpin/domain/pin/repository/PinRepository.java
@@ -25,7 +25,7 @@ public interface PinRepository extends JpaRepository <Pin, Long> {
             "FROM Pin p " +
             "LEFT JOIN p.genre g " +
             "WHERE p.creator = :creator " +
-            "ORDER BY p.listenedDate DESC")
+            "ORDER BY p.listenedDate DESC, p.pinId DESC")
     Page<Object[]> findPinFeed(@Param("creator") Member creator, Pageable pageable);
 
     List<Pin> findAllByPlace(Place place);

--- a/src/main/java/sws/songpin/domain/pin/service/PinService.java
+++ b/src/main/java/sws/songpin/domain/pin/service/PinService.java
@@ -14,10 +14,7 @@ import sws.songpin.domain.member.service.MemberService;
 import sws.songpin.domain.model.Visibility;
 import sws.songpin.domain.pin.dto.request.PinAddRequestDto;
 import sws.songpin.domain.pin.dto.request.PinUpdateRequestDto;
-import sws.songpin.domain.pin.dto.response.PinBasicListResponseDto;
-import sws.songpin.domain.pin.dto.response.PinBasicUnitDto;
-import sws.songpin.domain.pin.dto.response.PinFeedListResponseDto;
-import sws.songpin.domain.pin.dto.response.PinFeedUnitDto;
+import sws.songpin.domain.pin.dto.response.*;
 import sws.songpin.domain.pin.entity.Pin;
 import sws.songpin.domain.pin.repository.PinRepository;
 import sws.songpin.domain.place.entity.Place;
@@ -242,6 +239,12 @@ public class PinService {
     public Pin getPinById(Long pinId) {
         return pinRepository.findById(pinId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PIN_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public PinExistingInfoResponseDto getPinInfo(Long pinId) {
+        Pin pin = getPinById(pinId);
+        return PinExistingInfoResponseDto.from(pin);
     }
 
 }

--- a/src/main/java/sws/songpin/domain/pin/service/PinService.java
+++ b/src/main/java/sws/songpin/domain/pin/service/PinService.java
@@ -78,7 +78,7 @@ public class PinService {
         Genre genre = genreService.getGenreByGenreName(pinUpdateRequestDto.genreName());
         pin.updatePin(pinUpdateRequestDto.listenedDate(), pinUpdateRequestDto.memo(), pinUpdateRequestDto.visibility(), genre);
         pinRepository.save(pin);
-
+        updateSongAvgGenreName(pin.getSong());
         return pin.getSong().getSongId();
     }
 


### PR DESCRIPTION
# 구현 기능
 - avgGenreName 업데이트가 핀 수정 시에도 되도록 코드 넣어놨던 것 같은데 지금 보니까 빠져있어서 다시 추가했습니다.
- OrderBy PinId DESC를 추가했습니다
- 수정 전, 기존 사용자가 작성한 음악 핀의 정보를 확인할 수 있도록 불러옵니다.

# 구현 내용
- 핀 정보 조회 기능을 [API 명세서](https://www.notion.so/efub/46bd2fb0ca23419fb4d6ad9b6753ed9a )에 추가했습니다. 
- dto 구성은 다음과 같습니다. 
``` JSON
{
    "songImgPath": "https://i.scdn.co/image/ab67616d0000b273ca88c0dcebddf74a98c46134",
    "songTitle": "NO PAIN",
    "songArtist": "Silica Gel",
    "listenedDate": "2024-07-23",
    "placeName": "이화여자대학교 아산공학관",
    "genreName": "BALLAD",
    "memo": "메모메모",
    "visibility": "PUBLIC"
}
```
