### PR TITLE
[Hotfix] Comparator.nullsLast() 으로 null 핸들링

### DIFF
--- a/src/main/java/sws/songpin/domain/follow/service/FollowService.java
+++ b/src/main/java/sws/songpin/domain/follow/service/FollowService.java
@@ -74,7 +74,7 @@ public class FollowService {
                 })
                 // 우선순위대로 정렬 (1차: null > true > false, 2차: followId 높은 것부터)
                 .sorted(Comparator.comparing(FollowDto::isFollowing, Comparator.nullsFirst(Comparator.reverseOrder()))
-                        .thenComparing(FollowDto::followId, Comparator.reverseOrder()))
+                        .thenComparing(FollowDto::followId, Comparator.nullsLast(Comparator.reverseOrder())))
                 .collect(Collectors.toList());
         return FollowListResponseDto.from(targetMember.equals(currentMember), targetMember.getHandle(), followDtoList);
     }


### PR DESCRIPTION
# 구현 기능
  - 팔로잉, 팔로우에서 에러 발생
## 원인
  - Comparator 사용 시 null을 고려하지 못함: 
```
2024-08-08T02:18:08.995+09:00 ERROR 1 --- [nio-8080-exec-6] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: java.lang.NullPointerException: Cannot invoke "java.lang.Comparable.compareTo(Object)" because "c2" is null] with root cause
```

# Resolve
  - #154
