### PR TITLE
[Fix] 플레이리스트 표지(imgPathList) pinIndex 순서대로 정렬

### DIFF
--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -219,6 +219,7 @@ public class PlaylistService {
     @Transactional(readOnly = true)
     public PlaylistUnitDto convertToPlaylistUnitDto(Playlist playlist, Member currentMember) {
         List<String> imgPathList = playlist.getPlaylistPins().stream()
+                .sorted(Comparator.comparingInt(PlaylistPin::getPinIndex).reversed())
                 .map(playlistPin -> playlistPin.getPin().getSong().getImgPath())
                 .limit(3)
                 .collect(Collectors.toList());


### PR DESCRIPTION
# 구현 기능
  - 플레이리스트 표지(imgPathList) pinIndex 순서대로 정렬 추가
  - 플레이리스트 메인, 내 플레이리스트 목록 조회, 타 유저 플레이리스트 목록 조회, 내 북마크 목록 조회, 플레이리스트 검색 페이지의 플레이리스트 표지 이슈 해결

# Resolve
  - #154 
