### PR TITLE
[HotFix] 핀과 함께 memberStatus 보내기

### DIFF
--- a/src/main/java/sws/songpin/domain/member/entity/Member.java
+++ b/src/main/java/sws/songpin/domain/member/entity/Member.java
@@ -76,7 +76,6 @@ public class Member extends BaseTimeEntity {
 
     public void deactivate(String handle){
         this.status = Status.DELETED;
-        this.nickname = "(알 수 없음)";
         this.handle = handle;
     }
 

--- a/src/main/java/sws/songpin/domain/pin/service/PinService.java
+++ b/src/main/java/sws/songpin/domain/pin/service/PinService.java
@@ -121,10 +121,10 @@ public class PinService {
         Page<Pin> pinPage;
 
         if (onlyMyPins) {
-            // 내 핀만 보기 - 현재 사용자의 모든 핀 가져오기(visibility 상관없음)
+            // 내 핀만 보기 - 현재 사용자의 모든 핀 가져오기
             pinPage = pinRepository.findAllBySongAndCreator(song, currentMember, pageable);
         } else {
-            // 전체 핀 보기 - 내 핀 가져오기(visibility 상관없음) + 타유저의 공개 핀 가져오기
+            // 전체 핀 보기 - 내 핀 가져오기
             pinPage = pinRepository.findAllBySong(song, pageable);
         }
         Page<SongDetailsPinDto> songDetailsPinPage = pinPage.map(pin -> {

--- a/src/main/java/sws/songpin/domain/song/dto/response/SongDetailsPinDto.java
+++ b/src/main/java/sws/songpin/domain/song/dto/response/SongDetailsPinDto.java
@@ -1,5 +1,6 @@
 package sws.songpin.domain.song.dto.response;
 
+import sws.songpin.domain.member.entity.Status;
 import sws.songpin.domain.pin.entity.Pin;
 import sws.songpin.domain.model.Visibility;
 
@@ -9,6 +10,7 @@ public record SongDetailsPinDto(
         Long pinId,
         Long creatorId,
         String creatorNickname,
+        Status creatorStatus,
         LocalDate listenedDate,
         String memo,
         Visibility visibility,
@@ -22,6 +24,7 @@ public record SongDetailsPinDto(
                 pin.getPinId(),
                 pin.getCreator().getMemberId(),
                 pin.getCreator().getNickname(),
+                pin.getCreator().getStatus(),
                 pin.getListenedDate(),
                 memo,
                 pin.getVisibility(),


### PR DESCRIPTION
# 구현 기능
  - 서버 측에서 탈퇴한 회원의 닉네임을 (알 수 없음) 으로 변경하는 대신, 노래 상세보기 페이지의 핀에 creatorStatus를 함께 보내 해당 사항을 프론트에서 처리하도록 코드를 수정했습니다.

# 구현 상태 (선택)
https://www.notion.so/efub/memberStatus-1afdca2763b144aaa0a054ff64a8583a
관련 문서입니다. 

# Resolve
  - #163 
