### PR TITLE
[Feat] Map API 플레이리스트의 핀들 장소 좌표들 가져오기 개발

### DIFF
--- a/src/main/java/sws/songpin/domain/place/controller/MapController.java
+++ b/src/main/java/sws/songpin/domain/place/controller/MapController.java
@@ -47,4 +47,11 @@ public class MapController {
         MapPlaceFetchResponseDto responseDto = mapService.getMapPlacesOfMember(memberId);
         return ResponseEntity.ok(responseDto);
     }
+
+    @Operation(summary = "플레이리스트의 핀들 장소 좌표들 가져오기", description = "플레이리스트의 핀들 장소 좌표들을 가져옵니다.")
+    @GetMapping("/playlists/{playlistId}")
+    public ResponseEntity<?> getMapPlacesOfPlaylist(@PathVariable final Long playlistId) {
+        MapPlaceFetchResponseDto responseDto = mapService.getMapPlacesOfPlaylist(playlistId);
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/sws/songpin/domain/place/service/MapService.java
+++ b/src/main/java/sws/songpin/domain/place/service/MapService.java
@@ -86,6 +86,15 @@ public class MapService {
         return MapPlaceFetchResponseDto.from(dtoSlice);
     }
 
+    //// 플레이리스트 필터링
+    // 플레이리스트의 핀들 장소 좌표들 가져오기
+    public MapPlaceFetchResponseDto getMapPlacesOfPlaylist(Long playlistId) {
+        Pageable pageable = getCustomPageableForMap();
+        Slice<MapPlaceProjectionDto> dtoSlice = mapPlaceRepository.findPlacesWithHighPinIndexPlaylistPinsByPlaylist(playlistId, pageable);
+        return MapPlaceFetchResponseDto.from(dtoSlice);
+    }
+
+
     // 지도에 장소 좌표를 최대 300개 띄우도록 함
     private Pageable getCustomPageableForMap() {
         return PageRequest.of(0, 300);


### PR DESCRIPTION
# 구현 기능
  - 플레이리스트의 핀들 마커를 지도 위에 띄우는 작업을 기존에는 플레이리스트 상세정보 핀 목록 응답을 사용해서 하려 했었는데, 같은 장소에서 등록된 핀들을 묶어서 보내야 한다는 사실을 놓쳤었습니다. 이 기능 구현을 위해 신규 API를 개발했습니다.

# Resolve
  - #172