### PR TITLE
[Fix] SSE 알림 구독(subscribe) API 수정

### DIFF
--- a/src/main/java/sws/songpin/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/sws/songpin/domain/alarm/controller/AlarmController.java
@@ -19,9 +19,9 @@ public class AlarmController {
     private final AlarmService alarmService;
 
     @Operation(summary = "알림 구독", description = "알림을 구독합니다.")
-    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> subscribe() {
-        return ResponseEntity.ok(emitterService.subscribe());
+    @GetMapping(value = "/subscribe/{memberId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE) // Content-Type 지정
+    public ResponseEntity<SseEmitter> subscribe(@PathVariable("memberId") final Long memberId) {
+        return ResponseEntity.ok(emitterService.subscribe(memberId));
     }
 
     @Operation(summary = "알림 목록 조회 및 읽음 처리", description = "알림 목록을 조회하고 읽음 처리합니다.")

--- a/src/main/java/sws/songpin/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/sws/songpin/domain/alarm/controller/AlarmController.java
@@ -19,7 +19,7 @@ public class AlarmController {
     private final AlarmService alarmService;
 
     @Operation(summary = "알림 구독", description = "알림을 구독합니다.")
-    @PostMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> subscribe() {
         return ResponseEntity.ok(emitterService.subscribe());
     }

--- a/src/main/java/sws/songpin/domain/alarm/dto/response/AlarmUnitDto.java
+++ b/src/main/java/sws/songpin/domain/alarm/dto/response/AlarmUnitDto.java
@@ -10,10 +10,10 @@ public record AlarmUnitDto(
         LocalDateTime createdTime,
         Long senderId
 ) {
-    public static AlarmUnitDto from(Alarm alarm) {
+    public static AlarmUnitDto from(Alarm alarm, String message) {
         return new AlarmUnitDto(
                 alarm.getIsRead(),
-                alarm.getMessage(),
+                message,
                 alarm.getCreatedTime(),
                 alarm.getSender().getMemberId()
         );

--- a/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
@@ -30,8 +30,14 @@ public class EmitterService {
         return emitter;
     }
 
-    public void notify(Long memberId, Object data, String comment) {
-        sendToClient(memberId, data, comment);
+    private void sendToClientIfNewAlarmExists(Long memberId) {
+        Member member = memberService.getActiveMemberById(memberId);
+        Boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalse(member);
+        if (isMissedAlarms.equals(true)) {
+            sendToClient(member.getMemberId(), AlarmDefaultDataDto.from(true), "new sse alarm exists");
+        } else {
+            sendToClient(member.getMemberId(), AlarmDefaultDataDto.from(false), "new sse alarm doesn't exists");
+        }
     }
 
     private SseEmitter registerEmitter(Long memberId) {
@@ -44,14 +50,8 @@ public class EmitterService {
         return emitter;
     }
 
-    private void sendToClientIfNewAlarmExists(Long memberId) {
-        Member member = memberService.getActiveMemberById(memberId);
-        Boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalse(member);
-        if (isMissedAlarms.equals(true)) {
-            sendToClient(member.getMemberId(), AlarmDefaultDataDto.from(true), "new sse alarm exists");
-        } else {
-            sendToClient(member.getMemberId(), AlarmDefaultDataDto.from(false), "new sse alarm doesn't exists");
-        }
+    public void notify(Long memberId, Object data, String comment) {
+        sendToClient(memberId, data, comment);
     }
 
     private <T> void sendToClient(Long memberId, Object data, String comment) {

--- a/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
@@ -23,7 +23,7 @@ public class EmitterService {
     private final EmitterRepository emitterRepository;
     private final AlarmRepository alarmRepository;
 
-    private static final Long DEFAULT_TIMEOUT = 1L * 100;  // 0.1초
+    private static final Long DEFAULT_TIMEOUT = 1L * 60 * 1000;  // 1분
 
     public SseEmitter subscribe() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -47,9 +47,9 @@ public class SecurityConfig {
     }
 
     private static final String[] AUTH_WHITELIST = {
-            "/signup", "/login", "/login/pw", "/token",
-            "/mail/pw",
-            "/stats/**", "/map", "/map/period/**", "/map/playlists/**"
+            "/signup", "/login", "/login/pw", "/token", "/mail/pw",
+            "/stats/**", "/map", "/map/period/**", "/map/playlists/**",
+            "/alarms/subscribe/**"
     };
 
     @Bean


### PR DESCRIPTION
# 구현 기능
## SSE 알림 구독 API를 수정
### 문제 상황
  - 프론트엔드에서 사용하는 EventSource 기술이 헤더를 사용하지 않는데, 기존 알림 구독 API 에서는 Spring Security에서 해당 uri를 토큰 불필요하도록 열어주지 않았을 뿐 아니라 이 때문에 401 Unauthorized 에러가 발생하고 있었습니다.
  - 또한 SSE 구독은 무조건 GET 메소드만 지원한다는 것을 알지 못하여 POST 메소드를 사용하고 있었던 것도 문제점이었습니다.
### 해결
  - 현재 상황에서 이를 해결하기 위해 uri에 memberId를 넣어 전달하도록 하고 Spring Security의 화이트리스트 uri에도 알림 구독 API의 uri를 넣어주었습니다. 또한 API를 GET 메소드로 변경했습니다.
  - FE와의 기능 테스트는 현재 `test-deploy` 브랜치로 배포하여 진행했습니다. 현재는 https://api.songpin.n-e.kr/alarms/subscribe/{memberId} 여기에 무슨 memberId든 넣으면 로그인여부도 상관없이 알림 연결이 다 되는 상황입니다. (보안에 취약) 프론트엔드에서 event-source-polyfill 라이브러리를 사용하면 헤더를 쓸 수 있다고 하셔서 해당 부분에 대한 공부를 부탁드렸습니다. 

# Resolve
  - 이슈 태그(ex: #7)
