### PR TITLE
[Feat] 팔로워 삭제 api 추가, FollowRequestDto 변수명 memberId로 변경

### DIFF
--- a/src/main/java/sws/songpin/domain/follow/controller/FollowController.java
+++ b/src/main/java/sws/songpin/domain/follow/controller/FollowController.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sws.songpin.domain.follow.dto.request.FollowRequestDto;
-import sws.songpin.domain.follow.entity.Follow;
 import sws.songpin.domain.follow.service.FollowService;
 
 @Tag(name = "Follow", description = "Follow 관련 API입니다.")
@@ -18,7 +17,7 @@ import sws.songpin.domain.follow.service.FollowService;
 public class FollowController {
     private final FollowService followService;
 
-    @Operation(summary = "팔로잉 상태 변경 혹은 팔로워 삭제", description = "다른 유저를 팔로잉 또는 팔로우 취소하거나, 나의 팔로워를 삭제합니다.")
+    @Operation(summary = "팔로잉 상태 변경", description = "다른 유저를 팔로잉 또는 팔로우 취소합니다.")
     @PutMapping
     public ResponseEntity<?> changeFollow(@RequestBody @Valid FollowRequestDto requestDto) {
         boolean isCreated = followService.createOrDeleteFollow(requestDto);
@@ -27,5 +26,12 @@ public class FollowController {
         } else {
             return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         }
+    }
+
+    @Operation(summary = "팔로워 삭제", description = "나의 팔로워를 삭제합니다.")
+    @DeleteMapping("/followers")
+    public ResponseEntity<?> deleteFollower(@RequestBody @Valid FollowRequestDto requestDto) {
+        followService.deleteFollower(requestDto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/sws/songpin/domain/follow/dto/request/FollowRequestDto.java
+++ b/src/main/java/sws/songpin/domain/follow/dto/request/FollowRequestDto.java
@@ -5,7 +5,7 @@ import sws.songpin.domain.follow.entity.Follow;
 import sws.songpin.domain.member.entity.Member;
 
 public record FollowRequestDto(
-        @NotNull Long targetMemberId
+        @NotNull Long memberId
 ){
     public static Follow toEntity(Member follower, Member following) {
         return Follow.builder()


### PR DESCRIPTION
# 구현 기능
  - 팔로워 삭제 api를 추가하고, FollowRequestDto 변수명을 memberId로 변경했습니다.
  - 서비스 로직에서 UNAUTHORIZED_REQUEST가 발생하는 경우가 사라졌으므로 삭제했습니다.

# Resolve
  - #154
