### PR TITLE
[Fix] 타 유저 정보 조회 시 상대가 나의 팔로워인지 여부를 isFollowing로 전송

### DIFF
--- a/src/main/java/sws/songpin/domain/follow/service/FollowService.java
+++ b/src/main/java/sws/songpin/domain/follow/service/FollowService.java
@@ -37,7 +37,7 @@ public class FollowService {
         }
 
         Optional<Follow> followOptional = followRepository.findByFollowerAndFollowing(currentMember, targetMember);
-        if (followOptional.isPresent()) { // 팔로우가 존재하면 삭제
+        if (checkIfFollowExists(targetMember, currentMember)) { // 팔로우가 존재하면 삭제
             followRepository.delete(followOptional.get());
             return false;
         } else { // 팔로우 추가
@@ -63,9 +63,18 @@ public class FollowService {
         }
     }
 
-    public Boolean checkIfFollowing(Member following){
-        Member follower = memberService.getCurrentMember();
-        if (follower.equals(following)){
+    public Boolean checkIfFollowing(Member targetMember){
+        Member currentMember = memberService.getCurrentMember();
+        return checkIfFollowExists(currentMember, targetMember);
+    }
+
+    public Boolean checkIfFollower(Member targetMember) {
+        Member currentMember = memberService.getCurrentMember();
+        return checkIfFollowExists(targetMember, currentMember);
+    }
+
+    public Boolean checkIfFollowExists(Member follower, Member following) {
+        if (follower.equals(following)) {
             return null;
         }
         Optional<Follow> followOptional = followRepository.findByFollowerAndFollowing(follower, following);

--- a/src/main/java/sws/songpin/domain/member/dto/response/MemberProfileResponseDto.java
+++ b/src/main/java/sws/songpin/domain/member/dto/response/MemberProfileResponseDto.java
@@ -9,9 +9,10 @@ public record MemberProfileResponseDto(
         String handle,
         long followerCount,
         long followingCount,
-        Boolean isFollowing
+        Boolean isFollowing,
+        Boolean isFollower
 ) {
-    public static MemberProfileResponseDto from(Member member, long followerCount, long followingCount, Boolean isFollowing){
-        return new MemberProfileResponseDto(member.getProfileImg(), member.getNickname(), member.getHandle(), followerCount, followingCount, isFollowing);
+    public static MemberProfileResponseDto from(Member member, long followerCount, long followingCount, Boolean isFollowing, Boolean isFollower){
+        return new MemberProfileResponseDto(member.getProfileImg(), member.getNickname(), member.getHandle(), followerCount, followingCount, isFollowing, isFollower);
     }
 }

--- a/src/main/java/sws/songpin/domain/member/service/ProfileService.java
+++ b/src/main/java/sws/songpin/domain/member/service/ProfileService.java
@@ -48,10 +48,13 @@ public class ProfileService {
         //팔로잉 수
         long followingCount = followService.getFollowingCount(member);
 
-        //팔로우 여부
+        //내가 팔로잉중인지 여부
         Boolean isFollowing = followService.checkIfFollowing(member);
 
-        return MemberProfileResponseDto.from(member, followerCount, followingCount, isFollowing);
+        //해당 유저가 나의 팔로워인지 여부
+        Boolean isFollower = followService.checkIfFollower(member);
+
+        return MemberProfileResponseDto.from(member, followerCount, followingCount, isFollowing, isFollower);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# 구현 기능
  - 팔로워 삭제 기능 구현을 타 유저 정보 조회 시 가능하도록 구현하게 되면서 타 유저 정보 조회 시 상대가 나의 팔로워인지 여부를 isFollowing로 전송하도록 했습니다.

# Resolve
  - #154