### PR TITLE
[Feat] 알림 구독을 위해 클라이언트에서 헤더를 사용하도록 변경

### DIFF
--- a/src/main/java/sws/songpin/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/sws/songpin/domain/alarm/controller/AlarmController.java
@@ -19,9 +19,9 @@ public class AlarmController {
     private final AlarmService alarmService;
 
     @Operation(summary = "알림 구독", description = "알림을 구독합니다.")
-    @GetMapping(value = "/subscribe/{memberId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE) // Content-Type 지정
-    public ResponseEntity<SseEmitter> subscribe(@PathVariable("memberId") final Long memberId) {
-        return ResponseEntity.ok(emitterService.subscribe(memberId));
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE) // Content-Type 지정
+    public ResponseEntity<SseEmitter> subscribe() {
+        return ResponseEntity.ok(emitterService.subscribe());
     }
 
     @Operation(summary = "알림 목록 조회 및 읽음 처리", description = "알림 목록을 조회하고 읽음 처리합니다.")

--- a/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
@@ -24,14 +24,14 @@ public class EmitterService {
 
     private static final Long DEFAULT_TIMEOUT = 1L * 60 * 1000;  // 1분
 
-    public SseEmitter subscribe(Long memberId) {
-        SseEmitter emitter = registerEmitter(memberId);
-        sendToClientIfNewAlarmExists(memberId);
+    public SseEmitter subscribe() {
+        Member member = memberService.getCurrentMember();
+        SseEmitter emitter = registerEmitter(member.getMemberId());
+        sendToClientIfNewAlarmExists(member);
         return emitter;
     }
 
-    private void sendToClientIfNewAlarmExists(Long memberId) {
-        Member member = memberService.getActiveMemberById(memberId);
+    private void sendToClientIfNewAlarmExists(Member member) {
         Boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalse(member);
         if (isMissedAlarms.equals(true)) {
             sendToClient(member.getMemberId(), AlarmDefaultDataDto.from(true), "new sse alarm exists");

--- a/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
@@ -22,7 +22,7 @@ public class EmitterService {
     private final AlarmRepository alarmRepository;
     private final MemberService memberService;
 
-    private static final Long DEFAULT_TIMEOUT = 1L * 60 * 1000;  // 1분
+    private static final Long DEFAULT_TIMEOUT = 5L * 60 * 1000;  // 5분
 
     public SseEmitter subscribe() {
         Member member = memberService.getCurrentMember();

--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -48,8 +48,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/signup", "/login", "/login/pw", "/token", "/mail/pw",
-            "/stats/**", "/map", "/map/period/**", "/map/playlists/**",
-            "/alarms/subscribe/**"
+            "/stats/**", "/map", "/map/period/**", "/map/playlists/**"
     };
 
     @Bean


### PR DESCRIPTION
# 구현 기능
  - 알림 구독을 위해 클라이언트에서 헤더를 사용하도록 변경했습니다. (uri를 `/subscribe/memberId` 에서 `/subscribe`로 변경)

# Resolve
  - #154