### PR TITLE
[Refactor] 에러코드가 순서에 맞게 응답되도록 ObjectMapper를 사용

### DIFF
--- a/src/main/java/sws/songpin/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/sws/songpin/domain/alarm/controller/AlarmController.java
@@ -19,9 +19,9 @@ public class AlarmController {
     private final AlarmService alarmService;
 
     @Operation(summary = "알림 구독", description = "알림을 구독합니다.")
-    @GetMapping(value = "/subscribe/{memberId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE) // Content-Type 지정
-    public ResponseEntity<SseEmitter> subscribe(@PathVariable("memberId") final Long memberId) {
-        return ResponseEntity.ok(emitterService.subscribe(memberId));
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE) // Content-Type 지정
+    public ResponseEntity<SseEmitter> subscribe() {
+        return ResponseEntity.ok(emitterService.subscribe());
     }
 
     @Operation(summary = "알림 목록 조회 및 읽음 처리", description = "알림 목록을 조회하고 읽음 처리합니다.")

--- a/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
@@ -24,14 +24,14 @@ public class EmitterService {
 
     private static final Long DEFAULT_TIMEOUT = 1L * 60 * 1000;  // 1분
 
-    public SseEmitter subscribe(Long memberId) {
-        SseEmitter emitter = registerEmitter(memberId);
-        sendToClientIfNewAlarmExists(memberId);
+    public SseEmitter subscribe() {
+        Member member = memberService.getCurrentMember();
+        SseEmitter emitter = registerEmitter(member.getMemberId());
+        sendToClientIfNewAlarmExists(member);
         return emitter;
     }
 
-    private void sendToClientIfNewAlarmExists(Long memberId) {
-        Member member = memberService.getActiveMemberById(memberId);
+    private void sendToClientIfNewAlarmExists(Member member) {
         Boolean isMissedAlarms = alarmRepository.existsByReceiverAndIsReadFalse(member);
         if (isMissedAlarms.equals(true)) {
             sendToClient(member.getMemberId(), AlarmDefaultDataDto.from(true), "new sse alarm exists");

--- a/src/main/java/sws/songpin/global/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/sws/songpin/global/auth/JwtAuthenticationEntryPoint.java
@@ -1,40 +1,51 @@
 package sws.songpin.global.auth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.json.JSONObject;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import sws.songpin.global.exception.ErrorCode;
+import sws.songpin.global.exception.ErrorDto;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         Object exception = request.getAttribute("exception");
-        if(exception instanceof  ErrorCode){
+        if(exception instanceof ErrorCode){
             ErrorCode errorCode = (ErrorCode) exception;
-            setResponse(request, response,errorCode);
+            setResponse(request, response, errorCode);
             return;
         }
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
     }
 
-    private void setResponse(HttpServletRequest request, HttpServletResponse response, ErrorCode errorCode) throws IOException{
+    private void setResponse(HttpServletRequest request, HttpServletResponse response, ErrorCode errorCode) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("timestamp", LocalDateTime.now().toString());
-        jsonObject.put("status",errorCode.getStatus());
-        jsonObject.put("errorCode", errorCode.name());
-        jsonObject.put("message", errorCode.getMessage());
-        jsonObject.put("path", request.getRequestURI());
-        response.getWriter().println(jsonObject);
 
+        ErrorDto errorDto = new ErrorDto(
+                LocalDateTime.now().toString(),
+                errorCode.getStatus(),
+                errorCode.name(),
+                errorCode.getMessage(),
+                request.getRequestURI()
+        );
+        // ObjectMapper 설정 및 JSON 문자열 생성
+        String jsonString = objectMapper.writeValueAsString(errorDto);
+
+        // JSON 문자열 출력
+        response.getWriter().println(jsonString);
     }
 }

--- a/src/main/java/sws/songpin/global/config/AppConfig.java
+++ b/src/main/java/sws/songpin/global/config/AppConfig.java
@@ -1,7 +1,10 @@
 package sws.songpin.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -10,5 +13,12 @@ public class AppConfig {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        return objectMapper;
     }
 }

--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -48,8 +48,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/signup", "/login", "/login/pw", "/token", "/mail/pw",
-            "/stats/**", "/map", "/map/period/**", "/map/playlists/**",
-            "/alarms/subscribe/**"
+            "/stats/**", "/map", "/map/period/**", "/map/playlists/**"
     };
 
     @Bean


### PR DESCRIPTION
# 구현 기능
  - JwtAuthenticationEntryPoint에서 에러 발생 시 에러코드가 순서에 맞게 응답되도록 ObjectMapper를 사용했습니다.

# Resolve
  - #154
