### PR TITLE
[Fix] 검색 api 키워드 문자열에 특수문자 이스케이프 처리 로직 추가

### DIFF
--- a/src/main/java/sws/songpin/domain/member/repository/MemberRepository.java
+++ b/src/main/java/sws/songpin/domain/member/repository/MemberRepository.java
@@ -15,6 +15,6 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     boolean existsByHandle(String handle);
 
     // 유저 검색
-    @Query("SELECT m FROM Member m WHERE (m.handle LIKE %:keyword% OR m.nickname LIKE %:keyword%) AND m.status <> 'DELETED'")
+    @Query("SELECT m FROM Member m WHERE (m.handle LIKE %:keyword% ESCAPE '\\' OR m.nickname LIKE %:keyword% ESCAPE '\\') AND m.status <> 'DELETED'")
     Page<Member> findAllByHandleContainingOrNicknameContaining(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/sws/songpin/domain/member/service/MemberService.java
+++ b/src/main/java/sws/songpin/domain/member/service/MemberService.java
@@ -18,6 +18,8 @@ import sws.songpin.global.exception.ErrorCode;
 
 import java.util.Optional;
 
+import static sws.songpin.global.common.EscapeSpecialCharactersService.escapeSpecialCharacters;
+
 @Slf4j
 @Service
 @Transactional
@@ -28,7 +30,9 @@ public class MemberService {
     // 유저 검색
     @Transactional(readOnly = true)
     public MemberSearchResponseDto searchMembers(String keyword, Pageable pageable) {
-        Page<Member> memberPage = memberRepository.findAllByHandleContainingOrNicknameContaining(keyword, pageable);
+        // 키워드의 이스케이프 처리
+        String escapedWord = escapeSpecialCharacters(keyword);
+        Page<Member> memberPage = memberRepository.findAllByHandleContainingOrNicknameContaining(escapedWord, pageable);
         Long currentMemberId = getCurrentMember().getMemberId();
 
         // Page<Member>를 Page<MemberUnitDto>로 변환

--- a/src/main/java/sws/songpin/domain/pin/repository/PinRepository.java
+++ b/src/main/java/sws/songpin/domain/pin/repository/PinRepository.java
@@ -17,8 +17,10 @@ public interface PinRepository extends JpaRepository <Pin, Long> {
     List<Pin> findBySong(Song song);
     int countBySong(Song song);
     int countByPlace(Place place);
+
     @Query("SELECT p FROM Pin p WHERE p.song = :song ORDER BY p.listenedDate DESC, p.pinId DESC")
     Page<Pin> findAllBySong(@Param("song") Song song, Pageable pageable);
+
     @Query("SELECT p FROM Pin p WHERE p.song = :song AND p.creator = :creator ORDER BY p.listenedDate DESC, p.pinId DESC")
     Page<Pin> findAllBySongAndCreator(@Param("song") Song song, @Param("creator") Member creator, Pageable pageable);
 
@@ -31,12 +33,12 @@ public interface PinRepository extends JpaRepository <Pin, Long> {
             "ORDER BY p.listenedDate DESC, p.pinId DESC")
     Page<Object[]> findPinFeed(@Param("creator") Member creator, Pageable pageable);
 
-    List<Pin> findAllByPlace(Place place);
     @Query("SELECT p FROM Pin p WHERE p.creator = :creator AND YEAR(p.listenedDate) = :year AND MONTH(p.listenedDate) = :month")
     List<Pin> findAllByCreatorAndDate(@Param("creator") Member creator, @Param("year") int year, @Param("month") int month);
 
     @Query("SELECT COUNT(p) FROM Pin p WHERE YEAR(p.listenedDate) = :currentYear")
     long countByListenedDateYear(@Param("currentYear") int currentYear);
+
     @Query("SELECT p.genre.genreName, COUNT(p) FROM Pin p GROUP BY p.genre ORDER BY COUNT(p) DESC")
     List<Object[]> findMostPopularGenreName();
 

--- a/src/main/java/sws/songpin/domain/pin/service/PinService.java
+++ b/src/main/java/sws/songpin/domain/pin/service/PinService.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static sws.songpin.global.common.EscapeSpecialCharactersService.escapeSpecialCharacters;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -212,9 +214,11 @@ public class PinService {
     // 마이페이지에서 내 핀 검색
     @Transactional(readOnly = true)
     public MyPinSearchResponseDto searchMyPins(String keyword, Pageable pageable) {
-        Member currentMember = memberService.getCurrentMember();
-        Long currentMemberId = currentMember.getMemberId();
-        String keywordNoSpaces = keyword.replace(" ", "");
+        // 키워드의 이스케이프 처리 및 띄어쓰기 제거
+        String escapedWord = escapeSpecialCharacters(keyword);
+        String keywordNoSpaces = escapedWord.replace(" ", "");
+
+        Long currentMemberId = memberService.getCurrentMember().getMemberId();
         Page<Object[]> myPinPage = pinRepository.findAllBySongNameOrArtistOrPlaceNameContainingIgnoreSpaces(currentMemberId, keywordNoSpaces, pageable);
 
         Page<PinBasicUnitDto> myPinUnitPage = myPinPage.map(objects -> {

--- a/src/main/java/sws/songpin/domain/place/service/MapService.java
+++ b/src/main/java/sws/songpin/domain/place/service/MapService.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sws.songpin.domain.genre.entity.GenreName;
-import sws.songpin.domain.member.entity.Member;
 import sws.songpin.domain.member.service.MemberService;
 import sws.songpin.domain.place.dto.request.MapBoundCoordsDto;
 import sws.songpin.domain.place.dto.request.MapFetchEntirePeriodRequestDto;
@@ -23,6 +22,7 @@ import sws.songpin.global.exception.ErrorCode;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
+
 @Slf4j
 @Service
 @Transactional(readOnly = true) // Transaction 모두 읽기 전용

--- a/src/main/java/sws/songpin/domain/place/service/PlaceService.java
+++ b/src/main/java/sws/songpin/domain/place/service/PlaceService.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static sws.songpin.global.common.EscapeSpecialCharactersService.escapeSpecialCharacters;
+
 @Slf4j
 @Service
 @Transactional
@@ -56,8 +58,10 @@ public class PlaceService {
 
     // 장소 검색 (네이티브 쿼리 이용)
     public PlaceSearchResponseDto searchPlaces(String keyword, SortBy sortBy, Pageable pageable) {
-        // 키워드의 띄어쓰기를 제거하여 띄어쓰기 없앤 장소이름을 검색
-        String keywordNoSpaces = keyword.replace(" ", "");
+        // 키워드의 이스케이프 처리 및 띄어쓰기 제거
+        String escapedWord = escapeSpecialCharacters(keyword);
+        String keywordNoSpaces = escapedWord.replace(" ", "");
+
         Page<Object[]> placePage;
         switch (sortBy) {
             case COUNT -> placePage = placeRepository.findAllByPlaceNameContainingIgnoreSpacesOrderByCount(keywordNoSpaces, pageable);

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sws.songpin.domain.bookmark.entity.Bookmark;
 import sws.songpin.domain.bookmark.repository.BookmarkRepository;
 import sws.songpin.domain.follow.service.FollowService;
 import sws.songpin.domain.member.entity.Member;

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -28,6 +28,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static sws.songpin.global.common.EscapeSpecialCharactersService.escapeSpecialCharacters;
+
 @Slf4j
 @Service
 @Transactional
@@ -194,7 +196,10 @@ public class PlaylistService {
     // 플레이리스트 검색
     @Transactional(readOnly = true)
     public Object searchPlaylists(String keyword, SortBy sortBy, Pageable pageable) {
-        String keywordNoSpaces = keyword.replace(" ", "");
+        // 키워드의 이스케이프 처리 및 띄어쓰기 제거
+        String escapedWord = escapeSpecialCharacters(keyword);
+        String keywordNoSpaces = escapedWord.replace(" ", "");
+
         Page<Object[]> playlistPage;
         Member currentMember = memberService.getCurrentMember();
         Long currentMemberId = currentMember.getMemberId();

--- a/src/main/java/sws/songpin/domain/playlistpin/repository/PlaylistPinRepository.java
+++ b/src/main/java/sws/songpin/domain/playlistpin/repository/PlaylistPinRepository.java
@@ -9,7 +9,5 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PlaylistPinRepository extends JpaRepository<PlaylistPin, Long> {
-    List<PlaylistPin> findAllByPlaylist(Playlist playlist);
-    Optional<Boolean> existsByPlaylistAndPin(Playlist playlist, Pin pin);
     List<PlaylistPin> findAllByPin(Pin pin);
 }

--- a/src/main/java/sws/songpin/domain/song/service/SongService.java
+++ b/src/main/java/sws/songpin/domain/song/service/SongService.java
@@ -12,8 +12,6 @@ import sws.songpin.domain.member.service.MemberService;
 import sws.songpin.domain.model.SortBy;
 import sws.songpin.domain.pin.entity.Pin;
 import sws.songpin.domain.pin.repository.PinRepository;
-import sws.songpin.domain.place.dto.response.PlaceSearchResponseDto;
-import sws.songpin.domain.place.dto.response.PlaceUnitDto;
 import sws.songpin.domain.song.dto.request.SongAddRequestDto;
 import sws.songpin.domain.song.dto.response.*;
 import sws.songpin.domain.song.entity.Song;

--- a/src/main/java/sws/songpin/domain/song/service/SongService.java
+++ b/src/main/java/sws/songpin/domain/song/service/SongService.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static sws.songpin.global.common.EscapeSpecialCharactersService.escapeSpecialCharacters;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -37,6 +39,7 @@ public class SongService {
     private final PinRepository pinRepository;
     private final MemberService memberService;
 
+    // Spotify
     @Transactional(readOnly = true)
     public List<SpotifySearchDto> searchTracks(String keyword, int offset) {
         List<Track> tracks = spotifyUtil.searchTracks(keyword, offset);
@@ -65,9 +68,11 @@ public class SongService {
     // 노래 검색
     @Transactional(readOnly = true)
     public SongSearchResponseDto searchSongs(String keyword, SortBy sortBy, Pageable pageable) {
-        String keywordNoSpaces = keyword.replace(" ", "");
-        Page<Object[]> songPage;
+        // 키워드의 이스케이프 처리 및 띄어쓰기 제거
+        String escapedWord = escapeSpecialCharacters(keyword);
+        String keywordNoSpaces = escapedWord.replace(" ", "");
 
+        Page<Object[]> songPage;
         switch (sortBy) {
             case NEWEST -> songPage = songRepository.findAllBySongNameOrArtistContainingIgnoreSpacesOrderByNewest(keywordNoSpaces, pageable);
             case COUNT -> songPage = songRepository.findAllBySongNameOrArtistContainingIgnoreSpacesOrderByCount(keywordNoSpaces, pageable);

--- a/src/main/java/sws/songpin/global/common/EscapeSpecialCharactersService.java
+++ b/src/main/java/sws/songpin/global/common/EscapeSpecialCharactersService.java
@@ -1,0 +1,19 @@
+package sws.songpin.global.common;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class EscapeSpecialCharactersService {
+
+    public static String escapeSpecialCharacters(String keyword) {
+        if (keyword != null) {
+            // 역슬래시(\)를 먼저 이스케이프 처리
+            keyword = keyword.replace("\\", "\\\\");
+            // %와 _를 이스케이프 처리
+            keyword = keyword.replace("%", "\\%")
+                    .replace("_", "\\_");
+        }
+        return keyword;
+    }
+
+}


### PR DESCRIPTION
# 구현 기능
  - 검색어에 sql에서 쓰이는 특수문자인 %, _가 포함될 경우 해당 문자로 인식되지 않는 문제가 존재.
  - 이를 해결하기 위해 `EscapeSpecialCharactersService` 서비스에 정적 메소드를 만들어 문자열에서 , %, _특수문자들에 \를 앞에 붙여 이스케이프 처리했습니다.
  - JPQL에서는 ESCAPE '\'를 해야 하는데 nativeQuery에서는 해당 부분을 적어줄 필요가 없더군요.
# Resolve
  - #202