### PR TITLE
[Fix] Spotify 노래 검색 결과에서 아티스트명을 , 로 구분

### DIFF
--- a/src/main/java/sws/songpin/domain/song/spotify/SpotifyUtil.java
+++ b/src/main/java/sws/songpin/domain/song/spotify/SpotifyUtil.java
@@ -93,6 +93,6 @@ public class SpotifyUtil {
         for (var artist : track.getArtists()) {
             artistNames.add(artist.getName());
         }
-        return String.join(" ", artistNames);
+        return String.join(", ", artistNames);
     }
 }


### PR DESCRIPTION
# 구현 기능
  - Spotify 노래 검색 결과에서 여러 아티스트들이 존재할 때 아티스트명이 ', '로 구분되어 표출되도록 수정했습니다.

# Resolve
  - #154
