### PR TITLE
[Feat] Role enum 추가, Member Builder 메소드에 ROLE_USER 디폴트 설정 추가

### DIFF
--- a/src/main/java/sws/songpin/domain/member/entity/Member.java
+++ b/src/main/java/sws/songpin/domain/member/entity/Member.java
@@ -53,6 +53,11 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    @Column(name = "role", length = 20)
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
     @OneToMany(mappedBy = "creator", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Pin> pins;
 
@@ -65,6 +70,7 @@ public class Member extends BaseTimeEntity {
         this.handle= handle;
         this.profileImg = ProfileImg.POP;
         this.status = Status.ACTIVE;
+        this.role = Role.ROLE_USER;
         this.pins = new ArrayList<>();
     }
 

--- a/src/main/java/sws/songpin/domain/member/entity/Role.java
+++ b/src/main/java/sws/songpin/domain/member/entity/Role.java
@@ -1,0 +1,6 @@
+package sws.songpin.domain.member.entity;
+
+public enum Role {
+    ROLE_USER,
+    ROLE_ADMIN
+}


### PR DESCRIPTION
# 구현 기능
  - Role enum을 만들어 ROLE_USER와 ROLE_ADMIN으로 나누었습니다. Member Builder 메소드에 ROLE_USER 디폴트 설정을 추가했습니다.
  - 로컬 DB로 테스트 하신다면 기존 계정들이 ROLE_ADMIN으로 될 텐데 mysql workbench에서 아래의 명령어를 입력하면 컬럼값들이 모두 ROLE_USER로 바뀝니다.
```
UPDATE songpindb.member SET role = 'ROLE_USER';
```
# Resolve
  - #154
