### PR TITLE
[Deploy] 배포 v0.6.6 - 토큰 없이 프로필 조회 가능하도록 수정, Spotify 노래 검색 결과에서 아티스트명을 컴마로 구분

### DIFF
--- a/src/main/java/sws/songpin/domain/member/service/ProfileService.java
+++ b/src/main/java/sws/songpin/domain/member/service/ProfileService.java
@@ -35,7 +35,7 @@ public class ProfileService {
     @Transactional(readOnly = true)
     public MemberProfileResponseDto getMemberProfile(String handle){
         Member member = memberService.getActiveMemberByHandle(handle);
-        Member currentMember = memberService.getCurrentMember();
+        Member currentMember = memberService.getCurrentMemberOrNull();
 
         //조회하려는 회원이 본인인 경우 예외 처리
         if (member.equals(currentMember)){
@@ -49,10 +49,10 @@ public class ProfileService {
         long followingCount = followService.getFollowingCount(member);
 
         //내가 팔로잉중인지 여부
-        Boolean isFollowing = followService.checkIfFollowing(member);
+        Boolean isFollowing = (currentMember != null) ? followService.checkIfFollowing(member) : false;
 
         //해당 유저가 나의 팔로워인지 여부
-        Boolean isFollower = followService.checkIfFollower(member);
+        Boolean isFollower = (currentMember != null) ? followService.checkIfFollower(member) : false;
 
         return MemberProfileResponseDto.from(member, followerCount, followingCount, isFollowing, isFollower);
     }

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -145,14 +145,14 @@ public class PlaylistService {
     @Transactional(readOnly = true)
     public PlaylistListResponseDto getMemberPlaylists(String handle) {
         Member creator = memberService.getActiveMemberByHandle(handle);
-        Member currentMember = memberService.getCurrentMember();
+        Member currentMember = memberService.getCurrentMemberOrNull();
         return getMemberPlaylists(creator, currentMember);
     }
 
     @Transactional(readOnly = true)
     public PlaylistListResponseDto getMemberPlaylists(Member creator, Member currentMember) {
         List<Playlist> playlists;
-        if (creator.equals(currentMember)) {
+        if (currentMember != null && creator.equals(currentMember)) {
             playlists = playlistRepository.findAllByCreator(creator);
         } else {
             playlists = playlistRepository.findAllPublicByCreator(creator);

--- a/src/main/java/sws/songpin/domain/song/spotify/SpotifyUtil.java
+++ b/src/main/java/sws/songpin/domain/song/spotify/SpotifyUtil.java
@@ -93,6 +93,6 @@ public class SpotifyUtil {
         for (var artist : track.getArtists()) {
             artistNames.add(artist.getName());
         }
-        return String.join(" ", artistNames);
+        return String.join(", ", artistNames);
     }
 }

--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -106,6 +106,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/places/{placeId}").permitAll()
                         .requestMatchers(HttpMethod.GET,"/playlists/main").authenticated()
                         .requestMatchers(HttpMethod.GET,"/playlists/{playlistId}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/members/{handle}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/members/{handle}/playlists").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/members/{handle}/feed").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
         ;


### PR DESCRIPTION
# 구현 기능
  - PR 206, 207 적용 배포
  - #206
  - #207

# Resolve
  - #186