### PR TITLE
[Feat] 신고 메일 전송 API 구현

### DIFF
--- a/src/main/java/sws/songpin/domain/alarm/entity/AlarmType.java
+++ b/src/main/java/sws/songpin/domain/alarm/entity/AlarmType.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AlarmType {
     FOLLOW("{0}(@{1})님이 팔로우했어요."),
+    REPORT("{0}(@{1})님에 대한 신고가 접수되었어요."),
     DEFAULT("{0}(@{1})님이 보낸 알림이에요.")
     ;
 

--- a/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
@@ -73,8 +73,8 @@ public class AlarmService {
         if (alarmSlice != null && alarmSlice.hasContent()) {
             for (Alarm alarm : alarmSlice) {
                 String message = switch (alarm.getAlarmType()){
-                    case AlarmType.FOLLOW -> MessageFormat.format(AlarmType.FOLLOW.getMessagePattern(), alarm.getSender().getNickname(), alarm.getSender().getHandle());
-                    case AlarmType.REPORT -> MessageFormat.format(AlarmType.REPORT.getMessagePattern(), alarm.getSender().getNickname(), alarm.getSender().getHandle());
+                    case FOLLOW -> MessageFormat.format(AlarmType.FOLLOW.getMessagePattern(), alarm.getSender().getNickname(), alarm.getSender().getHandle());
+                    case REPORT -> MessageFormat.format(AlarmType.REPORT.getMessagePattern(), alarm.getSender().getNickname(), alarm.getSender().getHandle());
                     case DEFAULT -> MessageFormat.format(AlarmType.DEFAULT.getMessagePattern(), alarm.getSender().getNickname(), alarm.getSender().getHandle());
                 };
                 alarmList.add(AlarmUnitDto.from(alarm, message));

--- a/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
@@ -53,7 +53,7 @@ public class AlarmService {
         Alarm alarm = Alarm.builder()
                 .alarmType(AlarmType.REPORT)
                 .message(message)
-                .sender(reported)   // 이후 운영자 계정이 생기면 이 부분 수정
+                .sender(reported)
                 .receiver(reporter)
                 .isRead(false)
                 .build();
@@ -72,7 +72,11 @@ public class AlarmService {
         Slice<Alarm> alarmSlice = alarmRepository.findByReceiverOrderByCreatedTimeDesc(currentMember, pageable);
         if (alarmSlice != null && alarmSlice.hasContent()) {
             for (Alarm alarm : alarmSlice) {
-                String message = alarm.getMessage();
+                String message = switch (alarm.getAlarmType()){
+                    case AlarmType.FOLLOW -> MessageFormat.format(AlarmType.FOLLOW.getMessagePattern(), alarm.getSender().getNickname(), alarm.getSender().getHandle());
+                    case AlarmType.REPORT -> MessageFormat.format(AlarmType.REPORT.getMessagePattern(), alarm.getSender().getNickname(), alarm.getSender().getHandle());
+                    case DEFAULT -> MessageFormat.format(AlarmType.DEFAULT.getMessagePattern(), alarm.getSender().getNickname(), alarm.getSender().getHandle());
+                };
                 alarmList.add(AlarmUnitDto.from(alarm, message));
                 alarm.readAlarm();
             }

--- a/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
@@ -47,6 +47,19 @@ public class AlarmService {
         alarmRepository.save(alarm);
         emitterService.notify(following.getMemberId(), AlarmDefaultDataDto.from(true), "new alarm");
     }
+    // 신고 접수 알림 생성
+    public void createReportAlarm(Member reporter, Member reported) {
+        String message = MessageFormat.format(AlarmType.REPORT.getMessagePattern(), reported.getNickname(), reported.getHandle());
+        Alarm alarm = Alarm.builder()
+                .alarmType(AlarmType.REPORT)
+                .message(message)
+                .sender(null)
+                .receiver(reporter)
+                .isRead(false)
+                .build();
+        alarmRepository.save(alarm);
+        emitterService.notify(reporter.getMemberId(), AlarmDefaultDataDto.from(true), "new alarm");
+    }
 
     public void deleteAllAlarmsOfMember(Member member){
         alarmRepository.deleteAllBySender(member);

--- a/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/AlarmService.java
@@ -53,7 +53,7 @@ public class AlarmService {
         Alarm alarm = Alarm.builder()
                 .alarmType(AlarmType.REPORT)
                 .message(message)
-                .sender(null)
+                .sender(reported)   // 이후 운영자 계정이 생기면 이 부분 수정
                 .receiver(reporter)
                 .isRead(false)
                 .build();
@@ -72,7 +72,7 @@ public class AlarmService {
         Slice<Alarm> alarmSlice = alarmRepository.findByReceiverOrderByCreatedTimeDesc(currentMember, pageable);
         if (alarmSlice != null && alarmSlice.hasContent()) {
             for (Alarm alarm : alarmSlice) {
-                String message = MessageFormat.format(AlarmType.FOLLOW.getMessagePattern(), alarm.getSender().getNickname(), alarm.getSender().getHandle());
+                String message = alarm.getMessage();
                 alarmList.add(AlarmUnitDto.from(alarm, message));
                 alarm.readAlarm();
             }

--- a/src/main/java/sws/songpin/domain/email/controller/EmailController.java
+++ b/src/main/java/sws/songpin/domain/email/controller/EmailController.java
@@ -7,22 +7,31 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sws.songpin.domain.email.dto.EmailRequestDto;
+import sws.songpin.domain.email.dto.ReportRequestDto;
 import sws.songpin.domain.email.service.EmailService;
 
 @Tag(name = "Email", description = "Email 관련 API입니다.")
 @RestController
+@RequestMapping("/mail")
 @RequiredArgsConstructor
 public class EmailController {
 
     private final EmailService emailService;
 
     @Operation(summary = "비밀번호 재설정 이메일 전송", description = "요청받은 이메일로 비밀번호 재설정 링크 전달")
-    @PostMapping("/mail/pw")
+    @PostMapping("/pw")
     public ResponseEntity<?> sendPasswordEmail(@RequestBody @Valid EmailRequestDto requestDto){
         emailService.sendPasswordEmail(requestDto);
         return ResponseEntity.ok().build();
+    }
 
+    @Operation(summary = "유저 신고 메일 전송", description = "유저 신고 내역을 담은 보고서를 운영자 메일로 전송")
+    @PostMapping("/report")
+    public ResponseEntity<?> sendReportEmail(@RequestBody @Valid ReportRequestDto requestDto){
+        emailService.sendReportEmail(requestDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/sws/songpin/domain/email/controller/EmailController.java
+++ b/src/main/java/sws/songpin/domain/email/controller/EmailController.java
@@ -1,4 +1,4 @@
-package sws.songpin.domain.member.controller;
+package sws.songpin.domain.email.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -8,8 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import sws.songpin.domain.member.dto.request.EmailRequestDto;
-import sws.songpin.domain.member.service.EmailService;
+import sws.songpin.domain.email.dto.EmailRequestDto;
+import sws.songpin.domain.email.service.EmailService;
 
 @Tag(name = "Email", description = "Email 관련 API입니다.")
 @RestController

--- a/src/main/java/sws/songpin/domain/email/dto/EmailRequestDto.java
+++ b/src/main/java/sws/songpin/domain/email/dto/EmailRequestDto.java
@@ -1,4 +1,4 @@
-package sws.songpin.domain.member.dto.request;
+package sws.songpin.domain.email.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;

--- a/src/main/java/sws/songpin/domain/email/dto/ReportRequestDto.java
+++ b/src/main/java/sws/songpin/domain/email/dto/ReportRequestDto.java
@@ -1,0 +1,13 @@
+package sws.songpin.domain.email.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import sws.songpin.domain.model.ReportType;
+
+public record ReportRequestDto(
+        @NotNull Long reporterId,
+        @NotNull Long reportedId,
+        @NotNull ReportType reportType,
+        @Size(max = 200) String reason
+        ) {
+}

--- a/src/main/java/sws/songpin/domain/email/dto/ReportRequestDto.java
+++ b/src/main/java/sws/songpin/domain/email/dto/ReportRequestDto.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Size;
 import sws.songpin.domain.model.ReportType;
 
 public record ReportRequestDto(
-        @NotNull Long reporterId,
         @NotNull Long reportedId,
         @NotNull ReportType reportType,
         @Size(max = 200) String reason

--- a/src/main/java/sws/songpin/domain/email/service/EmailService.java
+++ b/src/main/java/sws/songpin/domain/email/service/EmailService.java
@@ -70,7 +70,7 @@ public class EmailService {
     }
 
     public void sendReportEmail(ReportRequestDto requestDto){
-        Long reporterId = requestDto.reporterId();
+        Long reporterId = memberService.getCurrentMember().getMemberId();
         Long reportedId = requestDto.reportedId();
         String reportedHandle = memberService.getActiveMemberById(reportedId).getHandle();
         String reportType = requestDto.reportType().toString();

--- a/src/main/java/sws/songpin/domain/email/service/EmailService.java
+++ b/src/main/java/sws/songpin/domain/email/service/EmailService.java
@@ -12,6 +12,7 @@ import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 import sws.songpin.domain.email.dto.EmailRequestDto;
 import jakarta.mail.internet.MimeMessage;
+import sws.songpin.domain.email.dto.ReportRequestDto;
 import sws.songpin.domain.member.service.MemberService;
 import sws.songpin.global.auth.RedisService;
 import sws.songpin.global.exception.CustomException;
@@ -46,10 +47,7 @@ public class EmailService {
         //요청받은 이메일로 가입한 회원이 탈퇴하거나 없는 경우 예외 처리
         memberService.getActiveMemberByEmail(email);
 
-
         String uuid = UUID.randomUUID().toString().replaceAll("-", "");
-
-
 
         String title = "[송핀] 비밀번호 재설정 링크 전송"; //이메일 제목
         String link = passwordUrl + "/" + uuid;
@@ -81,7 +79,42 @@ public class EmailService {
             throw new CustomException(ErrorCode.EMAIL_ERROR);
         }
 
+    }
 
+    public void sendReportEmail(ReportRequestDto requestDto){
+        Long reporterId = requestDto.reporterId();
+        Long reportedId = requestDto.reportedId();
+        String reportedHandle = memberService.getActiveMemberById(reportedId).getHandle();
+        String reportType = requestDto.reportType().toString();
+        String reason = requestDto.reason();
+
+        HashMap<String,Object> map = new HashMap<>();
+        map.put("reporterId", reporterId);
+        map.put("reportedId", reportedId);
+        map.put("reportedUrl", "https://www.songpin.kr/users/"+reportedHandle);
+        map.put("reportType", reportType);
+        map.put("reason", reason);
+
+        Context context = new Context();
+        context.setVariables(map); //템플릿에 전달할 데이터
+        String content = templateEngine.process("reportMail.html", context);
+
+        String title = "[유저 신고] " + reporterId + " → " + reportedId; //이메일 제목
+
+        //메일 전송
+        try{
+            MimeMessage mailMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mailMessage, true, "UTF-8");
+            helper.setFrom(fromMail); //이메일 발신 주소
+            helper.setTo(fromMail);  //이메일 송신 주소
+            helper.setSubject(title);  //이메일 제목
+            helper.setText(content, true);
+            helper.addInline("logo", new ClassPathResource(logoPath));
+
+            javaMailSender.send(mailMessage);
+        } catch (MessagingException e){
+            throw new CustomException(ErrorCode.EMAIL_ERROR);
+        }
     }
 
 }

--- a/src/main/java/sws/songpin/domain/email/service/EmailService.java
+++ b/src/main/java/sws/songpin/domain/email/service/EmailService.java
@@ -76,6 +76,11 @@ public class EmailService {
         String reportType = requestDto.reportType().toString();
         String reason = requestDto.reason();
 
+        //신고자 ID 와 신고 대상 ID 가 동일한 경우
+        if(reporterId.equals(reportedId)){
+            throw new CustomException(ErrorCode.REPORT_BAD_REQUEST);
+        }
+
         String title = "[유저 신고] " + reporterId + " → " + reportedId; //이메일 제목
 
         HashMap<String,Object> map = new HashMap<>();

--- a/src/main/java/sws/songpin/domain/email/service/EmailService.java
+++ b/src/main/java/sws/songpin/domain/email/service/EmailService.java
@@ -14,12 +14,14 @@ import sws.songpin.domain.email.dto.EmailRequestDto;
 import jakarta.mail.internet.MimeMessage;
 import sws.songpin.domain.email.dto.ReportRequestDto;
 import sws.songpin.domain.member.service.MemberService;
+import sws.songpin.domain.model.ReportType;
 import sws.songpin.global.auth.RedisService;
 import sws.songpin.global.exception.CustomException;
 import sws.songpin.global.exception.ErrorCode;
 
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.UUID;
 
@@ -73,7 +75,7 @@ public class EmailService {
         Long reporterId = memberService.getCurrentMember().getMemberId();
         Long reportedId = requestDto.reportedId();
         String reportedHandle = memberService.getActiveMemberById(reportedId).getHandle();
-        String reportType = requestDto.reportType().toString();
+        ReportType reportType = requestDto.reportType();
         String reason = requestDto.reason();
 
         //신고자 ID 와 신고 대상 ID 가 동일한 경우
@@ -87,7 +89,8 @@ public class EmailService {
         map.put("reporterId", reporterId);
         map.put("reportedId", reportedId);
         map.put("reportedUrl", "https://www.songpin.kr/users/"+reportedHandle);
-        map.put("reportType", reportType);
+        map.put("reportType", reportType+"("+reportType.getMessage()+")");
+        map.put("reportTime", LocalDateTime.now());
         map.put("reason", reason);
 
         Context context = new Context();

--- a/src/main/java/sws/songpin/domain/email/service/EmailService.java
+++ b/src/main/java/sws/songpin/domain/email/service/EmailService.java
@@ -1,4 +1,4 @@
-package sws.songpin.domain.member.service;
+package sws.songpin.domain.email.service;
 
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
@@ -10,14 +10,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
-import sws.songpin.domain.member.dto.request.EmailRequestDto;
+import sws.songpin.domain.email.dto.EmailRequestDto;
 import jakarta.mail.internet.MimeMessage;
+import sws.songpin.domain.member.service.MemberService;
 import sws.songpin.global.auth.RedisService;
 import sws.songpin.global.exception.CustomException;
 import sws.songpin.global.exception.ErrorCode;
 
 
-import javax.xml.catalog.Catalog;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.UUID;

--- a/src/main/java/sws/songpin/domain/model/ReportType.java
+++ b/src/main/java/sws/songpin/domain/model/ReportType.java
@@ -1,0 +1,25 @@
+package sws.songpin.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import sws.songpin.global.exception.CustomException;
+import sws.songpin.global.exception.ErrorCode;
+
+public enum ReportType {
+
+    SPAM,
+    FLOODING,
+    ABUSE,
+    DOXXING,
+    OFFENSIVE,
+    OTHER
+    ;
+
+    @JsonCreator
+    public static ReportType from(String s) {
+        try {
+            return ReportType.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
+    }
+}

--- a/src/main/java/sws/songpin/domain/model/ReportType.java
+++ b/src/main/java/sws/songpin/domain/model/ReportType.java
@@ -1,18 +1,24 @@
 package sws.songpin.domain.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import sws.songpin.global.exception.CustomException;
 import sws.songpin.global.exception.ErrorCode;
 
+@Getter
+@AllArgsConstructor
 public enum ReportType {
 
-    SPAM,
-    FLOODING,
-    ABUSE,
-    DOXXING,
-    OFFENSIVE,
-    OTHER
+    SPAM("스팸/홍보"),
+    FLOODING("도배"),
+    ABUSE("욕설/비방"),
+    DOXXING("개인정보 노출"),
+    OFFENSIVE("불쾌감 조성"),
+    OTHER("기타")
     ;
+
+    private final String message;
 
     @JsonCreator
     public static ReportType from(String s) {

--- a/src/main/java/sws/songpin/global/exception/ErrorCode.java
+++ b/src/main/java/sws/songpin/global/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     // 자신과 관련해 불가능한 요청
     MEMBER_BAD_REQUEST(400, "자기 자신은 이 경로를 통해 조회할 수 없습니다."),
     FOLLOW_BAD_REQUEST(400,"자기 자신은 팔로잉할 수 없습니다."),
+    REPORT_BAD_REQUEST(400, "자기 자신을 신고할 수 없습니다."),
 
     // 401 Unauthorized
     // 로그인 상태여야 하는 요청

--- a/src/main/resources/templates/email/reportMail.html
+++ b/src/main/resources/templates/email/reportMail.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="ko" style="box-sizing: border-box;">
+<head style="box-sizing: border-box;">
+    <meta charset="UTF-8" style="box-sizing: border-box;">
+    <title style="box-sizing: border-box;">Songpin Mail</title>
+    <link href="https://fonts.googleapis.com/css?family=Inter&display=swap" rel="stylesheet" style="box-sizing: border-box;">
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Inter', sans-serif; background-color: #f4f4f4;">
+
+<div style="width: 700px; margin: 0 auto; padding: 20px;">
+    <table style="width: 100%; border-collapse: collapse; background-color: #ffffff; box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.1); border-radius: 8px; overflow: hidden;">
+        <tr>
+            <td colspan="5" style="text-align: center; padding: 20px; background-color: #4CAF50;">
+                <img src="cid:logo" alt="logo" style="max-width: 150px; height: auto;">
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 40px; text-align: center;">
+                <h2 style="font-size: 18px; color: #333333; margin-bottom: 10px;">유저 신고 보고서</h2>
+                <p style="font-size: 14px; color: #555555; margin-bottom: 30px;">아래는 유저 신고의 세부 정보입니다:</p>
+                <table style="width: 100%; border-collapse: collapse;">
+                    <tr>
+                        <td style="width: 300px; padding: 15px; background-color: #f9f9f9; border-bottom: 1px solid #eeeeee;">
+                            <strong>신고자 ID:</strong>
+                        </td>
+                        <td style="padding: 15px; background-color: #f9f9f9; border-bottom: 1px solid #eeeeee;" th:text="${reporterId}">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="width: 300px; padding: 15px; background-color: #ffffff; border-bottom: 1px solid #eeeeee;">
+                            <strong>신고된 ID:</strong>
+                        </td>
+                        <td style="padding: 15px; background-color: #ffffff; border-bottom: 1px solid #eeeeee;" th:text="${reportedId}">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="width: 300px; padding: 15px; background-color: #f9f9f9; border-bottom: 1px solid #eeeeee;">
+                            <strong>신고 유형:</strong>
+                        </td>
+                        <td style="padding: 15px; background-color: #f9f9f9; border-bottom: 1px solid #eeeeee;" th:text="${reportType}">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="width: 300px; padding: 15px; background-color: #ffffff; border-bottom: 1px solid #eeeeee;">
+                            <strong>신고 사유:</strong>
+                        </td>
+                        <td style="padding: 25px 15px; background-color: #ffffff; border-bottom: 1px solid #eeeeee; height: auto; word-wrap: break-word; max-width: 500px;" th:text="${reason}">
+                        </td>
+                    </tr>
+                </table>
+                <div style="margin-top: 30px;">
+                    <a th:href="${reportedUrl}" style="padding: 12px 25px; background-color: #4CAF50; color: #ffffff; text-decoration: none; border-radius: 5px; font-weight: bold; display: inline-block;">신고된 사용자 프로필로 이동</a>
+                </div>
+            </td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/email/reportMail.html
+++ b/src/main/resources/templates/email/reportMail.html
@@ -35,16 +35,23 @@
                     </tr>
                     <tr>
                         <td style="width: 300px; padding: 15px; background-color: #f9f9f9; border-bottom: 1px solid #eeeeee;">
-                            <strong>신고 유형:</strong>
+                            <strong>신고 시간:</strong>
                         </td>
-                        <td style="padding: 15px; background-color: #f9f9f9; border-bottom: 1px solid #eeeeee;" th:text="${reportType}">
+                        <td style="padding: 15px; background-color: #f9f9f9; border-bottom: 1px solid #eeeeee;" th:text="${reportTime}">
                         </td>
                     </tr>
                     <tr>
                         <td style="width: 300px; padding: 15px; background-color: #ffffff; border-bottom: 1px solid #eeeeee;">
+                            <strong>신고 유형:</strong>
+                        </td>
+                        <td style="padding: 15px; background-color: #ffffff; border-bottom: 1px solid #eeeeee;" th:text="${reportType}">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="width: 300px; padding: 15px; background-color: #f9f9f9; border-bottom: 1px solid #eeeeee;">
                             <strong>신고 사유:</strong>
                         </td>
-                        <td style="padding: 25px 15px; background-color: #ffffff; border-bottom: 1px solid #eeeeee; height: auto; word-wrap: break-word; max-width: 500px;" th:text="${reason}">
+                        <td style="padding: 25px 15px; background-color: #f9f9f9; border-bottom: 1px solid #eeeeee; height: auto; word-wrap: break-word; max-width: 500px;" th:text="${reason}">
                         </td>
                     </tr>
                 </table>


### PR DESCRIPTION
# 구현 기능
  - URI가 /mail 로 시작하는 API 와 관련된 컨트롤러/DTO/서비스 구조를 리팩터링했습니다.  
     - 기존: /domain/member 하위 패키지에 EmailController, EmailService, ... 존재
     - 변경: /domain/email 하위 패키지에 EmailController, EmailService, ... 존재

  - 신고 메일 전송 API 구현
    - 요청 및 응답 형식은 API 명세서 참고

# 구현 상태 (선택)
  - 메일 전송 결과  
  ![image](https://github.com/user-attachments/assets/842b0f99-4289-4f01-9c6e-860d15240215)

# Resolve
  - #210 
