### PR TITLE
[HotFix] Follow와 Bookmark의 결과를 List로 다룸 + 트랜잭션 범위 축소

### DIFF
--- a/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
+++ b/src/main/java/sws/songpin/domain/alarm/service/EmitterService.java
@@ -3,7 +3,6 @@ package sws.songpin.domain.alarm.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import sws.songpin.domain.alarm.dto.ssedata.AlarmDefaultDataDto;
 import sws.songpin.domain.alarm.repository.AlarmRepository;
@@ -15,7 +14,6 @@ import java.io.IOException;
 
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class EmitterService {
     private final EmitterRepository emitterRepository;

--- a/src/main/java/sws/songpin/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/sws/songpin/domain/bookmark/repository/BookmarkRepository.java
@@ -11,7 +11,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
-    Optional<Bookmark> findByPlaylistAndMember(Playlist playlist, Member member);
+    boolean existsByPlaylistAndMember(Playlist playlist, Member member);
+    List<Bookmark> findAllByPlaylistAndMember(Playlist playlist, Member member);
     @Query("SELECT b FROM Bookmark b WHERE b.member = :member ORDER BY b.bookmarkId DESC")
     List<Bookmark> findAllByMember(Member member);
     void deleteAllByMember(Member member);

--- a/src/main/java/sws/songpin/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/sws/songpin/domain/follow/repository/FollowRepository.java
@@ -12,7 +12,7 @@ public interface FollowRepository extends JpaRepository<Follow,Long> {
     List<Follow> findAllByFollower(Member follower);
     Long countByFollowing(Member following);
     Long countByFollower(Member follower);
-    Optional<Follow> findByFollowerAndFollowing(Member follower, Member following);
+    List<Follow> findAllByFollowerAndFollowing(Member follower, Member following);
     void deleteAllByFollower(Member member);
     void deleteAllByFollowing(Member member);
 }

--- a/src/main/java/sws/songpin/domain/follow/service/FollowService.java
+++ b/src/main/java/sws/songpin/domain/follow/service/FollowService.java
@@ -45,7 +45,7 @@ public class FollowService {
             alarmService.createFollowAlarm(currentMember, targetMember);
             return true;
         } else { // 팔로우가 존재하면 삭제
-            followRepository.deleteAllInBatch(follows);
+            followRepository.deleteAll(follows);
             return false;
         }
     }
@@ -63,7 +63,7 @@ public class FollowService {
         if (follows.isEmpty()) {
             throw new CustomException(ErrorCode.FOLLOW_NOT_FOUND);
         } else { // 팔로우가 존재하면 삭제
-            followRepository.deleteAllInBatch(follows);
+            followRepository.deleteAll(follows);
         }
     }
 

--- a/src/main/java/sws/songpin/domain/member/service/HomeService.java
+++ b/src/main/java/sws/songpin/domain/member/service/HomeService.java
@@ -16,18 +16,16 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class HomeService {
     private final MemberService memberService;
     private final PinRepository pinRepository;
     private final PlaceRepository placeRepository;
 
-    @Transactional(readOnly = true)
     public HomeResponseDto getHome() {
         Member currentMember = memberService.getCurrentMember();
-        List<Pin> pins = pinRepository.findTop3ByOrderByPinIdDesc();
-        List<Place> places = placeRepository.findTop3ByOrderByPlaceIdDesc();
+        List<Pin> pins = findTop3ByOrderByPinIdDesc();
+        List<Place> places = findTop3ByOrderByPlaceIdDesc();
         // pinList
         List<PinBasicUnitDto> pinList = pins.stream()
                 .map(pin -> PinBasicUnitDto.from(pin, pin.getCreator().equals(currentMember)))
@@ -40,5 +38,15 @@ public class HomeService {
                 })
                 .collect(Collectors.toList());
         return HomeResponseDto.from(currentMember, pinList, placeList);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Pin> findTop3ByOrderByPinIdDesc() {
+        return pinRepository.findTop3ByOrderByPinIdDesc();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Place> findTop3ByOrderByPlaceIdDesc() {
+        return placeRepository.findTop3ByOrderByPlaceIdDesc();
     }
 }

--- a/src/main/java/sws/songpin/domain/member/service/MemberService.java
+++ b/src/main/java/sws/songpin/domain/member/service/MemberService.java
@@ -20,17 +20,15 @@ import java.util.Optional;
 import static sws.songpin.global.common.EscapeSpecialCharactersService.escapeSpecialCharacters;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
 
     // 유저 검색
-    @Transactional(readOnly = true)
     public MemberSearchResponseDto searchMembers(String keyword, Pageable pageable) {
         // 키워드의 이스케이프 처리
         String escapedWord = escapeSpecialCharacters(keyword);
-        Page<Member> memberPage = memberRepository.findAllByHandleContainingOrNicknameContaining(escapedWord, pageable);
+        Page<Member> memberPage = getSearchedMemberPage(escapedWord, pageable);
         Long currentMemberId = getCurrentMember().getMemberId();
 
         // Page<Member>를 Page<MemberUnitDto>로 변환
@@ -39,6 +37,11 @@ public class MemberService {
         );
         // MemberSearchResponseDto를 반환
         return MemberSearchResponseDto.from(memberUnitDtoPage);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Member> getSearchedMemberPage(String escapedWord, Pageable pageable) {
+        return memberRepository.findAllByHandleContainingOrNicknameContaining(escapedWord, pageable);
     }
 
     @Transactional(readOnly = true)
@@ -101,6 +104,7 @@ public class MemberService {
         return memberRepository.existsByHandle(handle);
     }
 
+    @Transactional
     public Member saveMember(Member member){
         return memberRepository.save(member);
     }

--- a/src/main/java/sws/songpin/domain/pin/service/PinService.java
+++ b/src/main/java/sws/songpin/domain/pin/service/PinService.java
@@ -32,6 +32,7 @@ import sws.songpin.global.exception.ErrorCode;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -104,9 +105,20 @@ public class PinService {
         List<Genre> genres = pinRepository.findBySong(song).stream()
                 .map(Pin::getGenre)
                 .collect(Collectors.toList());
-        Optional<GenreName> avgGenreName = songService.calculateAvgGenreName(genres);
+        Optional<GenreName> avgGenreName = calculateAvgGenreNameOfSong(genres);
         avgGenreName.ifPresent(song::setAvgGenreName);
         songRepository.save(song);
+    }
+
+    public Optional<GenreName> calculateAvgGenreNameOfSong(List<Genre> genres) {
+        Map<GenreName, Long> genreCount = genres.stream()
+                .collect(Collectors.groupingBy(Genre::getGenreName, Collectors.counting()));
+
+        return genreCount.entrySet().stream()
+                .sorted(Map.Entry.<GenreName, Long>comparingByValue().reversed()
+                        .thenComparing(Map.Entry::getKey))
+                .map(Map.Entry::getKey)
+                .findFirst();
     }
 
     // 현재 로그인된 사용자가 핀의 생성자인지 확인

--- a/src/main/java/sws/songpin/domain/place/service/MapService.java
+++ b/src/main/java/sws/songpin/domain/place/service/MapService.java
@@ -25,16 +25,18 @@ import java.util.List;
 
 @Slf4j
 @Service
-@Transactional(readOnly = true) // Transaction 모두 읽기 전용
 @RequiredArgsConstructor
 public class MapService {
 
     private final MapPlaceRepository mapPlaceRepository;
     private final MemberService memberService;
 
+    // 지도에 장소 좌표를 최대 300개 띄우도록 함
+    private static final Pageable pageable = PageRequest.of(0, 300);
+
     // 장소 좌표들 가져오기-전체 기간 & 장르 필터링
     public MapPlaceFetchResponseDto getMapPlacesWithinBoundsByEntirePeriod(MapFetchEntirePeriodRequestDto requestDto) {
-        List<GenreName> genreNameList =  getSelectedGenreNames(requestDto.genreNameFilters());
+        List<GenreName> genreNameList = getSelectedGenreNames(requestDto.genreNameFilters());
         Slice<MapPlaceProjectionDto> dtoSlice = getMapPlaceSlicesWithinBounds(requestDto.boundCoords(), genreNameList);
         return MapPlaceFetchResponseDto.from(dtoSlice);
     }
@@ -62,14 +64,14 @@ public class MapService {
     }
 
     // 날짜 범위 조건 걸지 않는 경우
+    @Transactional(readOnly = true)
     public Slice<MapPlaceProjectionDto> getMapPlaceSlicesWithinBounds(MapBoundCoordsDto dto, List<GenreName> genreNameList) {
-        Pageable pageable = getCustomPageableForMap();
         return mapPlaceRepository.findPlacesWithLatestPinsByGenre(dto.swLat(), dto.neLat(), dto.swLng(), dto.neLng(), genreNameList, pageable);
     }
 
     // 날짜 범위 조건 거는 경우
+    @Transactional(readOnly = true)
     public Slice<MapPlaceProjectionDto> getMapPlaceSlicesWithinBoundsAndDateRange(MapBoundCoordsDto dto, List<GenreName> genreNameList, LocalDate startDate, LocalDate endDate) {
-        Pageable pageable = getCustomPageableForMap();
         return mapPlaceRepository.findPlacesWithLatestPinsByGenreAndDateRange(dto.swLat(), dto.neLat(), dto.swLng(), dto.neLng(), genreNameList, startDate, endDate, pageable);
     }
 
@@ -84,23 +86,24 @@ public class MapService {
     //// 유저로 필터링
     // 유저가 핀을 등록한 장소 좌표들 가져오기
     public MapPlaceFetchResponseDto getMapPlacesOfMember(String handle) {
-        Long memberId = memberService.getActiveMemberByHandle(handle).getMemberId();
-        Pageable pageable = getCustomPageableForMap();
-        Slice<MapPlaceProjectionDto> dtoSlice = mapPlaceRepository.findPlacesWithLatestPinsByCreator(memberId, pageable);
-        return MapPlaceFetchResponseDto.from(dtoSlice);
+        return MapPlaceFetchResponseDto.from(getMapPlaceSlicesOfMember(handle));
     }
+
+    @Transactional(readOnly = true)
+    public Slice<MapPlaceProjectionDto> getMapPlaceSlicesOfMember(String handle) {
+        Long memberId = memberService.getActiveMemberByHandle(handle).getMemberId();
+        return mapPlaceRepository.findPlacesWithLatestPinsByCreator(memberId, pageable);
+    }
+
 
     //// 플레이리스트 필터링
     // 플레이리스트의 핀들 장소 좌표들 가져오기
     public MapPlaceFetchResponseDto getMapPlacesOfPlaylist(Long playlistId) {
-        Pageable pageable = getCustomPageableForMap();
-        Slice<MapPlaceProjectionDto> dtoSlice = mapPlaceRepository.findPlacesWithHighPinIndexPlaylistPinsByPlaylist(playlistId, pageable);
-        return MapPlaceFetchResponseDto.from(dtoSlice);
+        return MapPlaceFetchResponseDto.from(getMapPlaceSlicesOfPlaylist(playlistId));
     }
 
-
-    // 지도에 장소 좌표를 최대 300개 띄우도록 함
-    private Pageable getCustomPageableForMap() {
-        return PageRequest.of(0, 300);
+    @Transactional(readOnly = true) // Transaction 모두 읽기 전용
+    public Slice<MapPlaceProjectionDto> getMapPlaceSlicesOfPlaylist(Long playlistId) {
+        return mapPlaceRepository.findPlacesWithHighPinIndexPlaylistPinsByPlaylist(playlistId, pageable);
     }
 }

--- a/src/main/java/sws/songpin/domain/place/service/PlaceService.java
+++ b/src/main/java/sws/songpin/domain/place/service/PlaceService.java
@@ -61,10 +61,10 @@ public class PlaceService {
         // 키워드의 이스케이프 처리 및 띄어쓰기 제거
         String escapedWord = escapeSpecialCharacters(keyword);
         String keywordNoSpaces = escapedWord.replace(" ", "");
-        Page<Object[]> placePages = getPlacePages(sortBy, keywordNoSpaces, pageable);
+        Page<Object[]> placePage = getSearchedPlacePage(sortBy, keywordNoSpaces, pageable);
 
         // Page<Object[]>를 Page<PlaceUnitDto>로 변환
-        Page<PlaceUnitDto> placeUnitPage = placePages.map(objects -> {
+        Page<PlaceUnitDto> placeUnitPage = placePage.map(objects -> {
             Long placeId = ((Number) objects[0]).longValue();
             String placeName = (String) objects[1];
             int placePinCount = ((Number) objects[2]).intValue();
@@ -76,15 +76,15 @@ public class PlaceService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Object[]> getPlacePages(SortBy sortBy, String keywordNoSpaces, Pageable pageable) {
-        Page<Object[]> placePages;
+    public Page<Object[]> getSearchedPlacePage(SortBy sortBy, String keywordNoSpaces, Pageable pageable) {
+        Page<Object[]> placePage;
         switch (sortBy) {
-            case COUNT -> placePages = placeRepository.findAllByPlaceNameContainingIgnoreSpacesOrderByCount(keywordNoSpaces, pageable);
-            case NEWEST -> placePages = placeRepository.findAllByPlaceNameContainingIgnoreSpacesOrderByNewest(keywordNoSpaces, pageable);
-            case ACCURACY -> placePages = placeRepository.findAllByPlaceNameContainingIgnoreSpacesOrderByAccuracy(keywordNoSpaces, pageable);
+            case COUNT -> placePage = placeRepository.findAllByPlaceNameContainingIgnoreSpacesOrderByCount(keywordNoSpaces, pageable);
+            case NEWEST -> placePage = placeRepository.findAllByPlaceNameContainingIgnoreSpacesOrderByNewest(keywordNoSpaces, pageable);
+            case ACCURACY -> placePage = placeRepository.findAllByPlaceNameContainingIgnoreSpacesOrderByAccuracy(keywordNoSpaces, pageable);
             default -> throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
         }
-        return placePages;
+        return placePage;
     }
 
     // Place를 providerAddressId로 찾아 가져오거나 생성

--- a/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/sws/songpin/domain/playlist/service/PlaylistService.java
@@ -233,7 +233,7 @@ public class PlaylistService {
 
     @Transactional(readOnly = true)
     public boolean isPlaylistBookmarkedByMember(Playlist playlist, Member member) {
-        return bookmarkRepository.findByPlaylistAndMember(playlist, member).isPresent();
+        return bookmarkRepository.existsByPlaylistAndMember(playlist, member);
     }
 
     public void deleteAllPlaylistsOfMember(Member member) {

--- a/src/main/java/sws/songpin/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/sws/songpin/domain/statistics/service/StatisticsService.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
-@Transactional(readOnly = true) // Transaction 모두 읽기 전용
 @RequiredArgsConstructor
 public class StatisticsService {
     private final MapPlaceRepository mapPlaceRepository;
@@ -30,8 +29,7 @@ public class StatisticsService {
     // 종합 통계
 
     public StatsOverallResponseDto getOverallStats() {
-        int currentYear = LocalDate.now().getYear();
-        long totalPinCount = pinRepository.countByListenedDateYear(currentYear);
+        long totalPinCount = getTotalPinCount();
         Pageable pageable = PageRequest.of(0, 1);
         StatsPopularSongDto popularSong = getMostPopularSongDto(pageable).orElse(null);
         StatsPlaceUnitDto popularPlace = getMostPopularPlaceDto(pageable).orElse(null);
@@ -39,7 +37,12 @@ public class StatisticsService {
         return StatsOverallResponseDto.from(totalPinCount, popularSong, popularPlace, popularGenreName);
     }
 
-    private Optional<StatsPopularSongDto> getMostPopularSongDto(Pageable pageable) {
+    public long getTotalPinCount() {
+        return pinRepository.countByListenedDateYear(LocalDate.now().getYear());
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<StatsPopularSongDto> getMostPopularSongDto(Pageable pageable) {
         Slice<StatsSongProjectionDto> topSongsSlice = songRepository.findTopSongs(pageable);
         if (topSongsSlice != null && !topSongsSlice.getContent().isEmpty()) {
             return Optional.of(StatsPopularSongDto.from(topSongsSlice.getContent().get(0)));
@@ -47,7 +50,8 @@ public class StatisticsService {
         return Optional.empty();
     }
 
-    private Optional<StatsPlaceUnitDto> getMostPopularPlaceDto(Pageable pageable) {
+    @Transactional(readOnly = true)
+    public Optional<StatsPlaceUnitDto> getMostPopularPlaceDto(Pageable pageable) {
         Slice<StatsPlaceProjectionDto> topPlacesSlice = mapPlaceRepository.findTopPlaces(pageable);
         if (topPlacesSlice != null && !topPlacesSlice.getContent().isEmpty()) {
             return Optional.of(StatsPlaceUnitDto.from(topPlacesSlice.getContent().get(0)));
@@ -55,7 +59,8 @@ public class StatisticsService {
         return Optional.empty();
     }
 
-    private Optional<GenreName> getMostPopularGenreName() {
+    @Transactional(readOnly = true)
+    public Optional<GenreName> getMostPopularGenreName() {
         List<Object[]> objectList = pinRepository.findMostPopularGenreName();
         if (!objectList.isEmpty()) {
             return Optional.of(GenreName.from(objectList.get(0)[0].toString()));
@@ -63,6 +68,7 @@ public class StatisticsService {
             return Optional.empty();
         }
     }
+
 
     // 장르별 통계
 
@@ -74,7 +80,8 @@ public class StatisticsService {
         return StatsGenreResponseDto.from(placeUnitDtos, songUnitDtos);
     }
 
-    private List<StatsSongUnitDto> getTopSongsFromAllGenres(GenreName[] genreNames, Pageable pageable) {
+    @Transactional(readOnly = true)
+    public List<StatsSongUnitDto> getTopSongsFromAllGenres(GenreName[] genreNames, Pageable pageable) {
         List<StatsSongUnitDto> songUnitDtos = new ArrayList<>();
         for (GenreName genreName : genreNames) {
             Slice<StatsSongProjectionDto> dtoSlice = songRepository.findTopSongsByGenreName(genreName, pageable);
@@ -85,7 +92,8 @@ public class StatisticsService {
         return songUnitDtos;
     }
 
-    private List<StatsPlaceUnitDto> getTopPlacesFromAllGenres(GenreName[] genreNames, Pageable pageable) {
+    @Transactional(readOnly = true)
+    public List<StatsPlaceUnitDto> getTopPlacesFromAllGenres(GenreName[] genreNames, Pageable pageable) {
         List<StatsPlaceUnitDto> placeUnitDtos = new ArrayList<>();
         for (GenreName genreName : genreNames) {
             Slice<StatsPlaceProjectionDto> dtoSlice = mapPlaceRepository.findTopPlacesByGenreName(genreName, pageable);


### PR DESCRIPTION
# 구현 기능
  - 실배포에서 api의 호출이 잦아지면서 Follow와 Bookmark를 change 하는 것이 지연되어 삽입이 중복으로 이루어질 수 있게 됩니다. 이로 인해 Optional 메소드로 DB 접근 시 에러가 발생합니다. 이를 해결하기 위해 자료구조로 List를 이용하도록 고쳤습니다.
  - 동시성 문제를 해결하는 방법에 대해 조사해 보았으나 이렇게 처리하는 것이 가장 간단할 것으로 생각했습니다.
  - 또한 DB connection pool의 이슈로 트랜잭션 범위가 축소되도록 리팩토링했습니다.

# Resolve
  - 