### PR TITLE
[Feat] AccessDeniedException 처리 관련

### DIFF
--- a/src/main/java/sws/songpin/global/auth/CustomAccessDeniedHandler.java
+++ b/src/main/java/sws/songpin/global/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,23 @@
+package sws.songpin.global.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "Access Denied");
+    }
+
+}

--- a/src/main/java/sws/songpin/global/auth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/sws/songpin/global/auth/CustomAuthenticationEntryPoint.java
@@ -1,7 +1,6 @@
 package sws.songpin.global.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,7 +16,7 @@ import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
-public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
     private final ObjectMapper objectMapper;
 
     @Override

--- a/src/main/java/sws/songpin/global/auth/CustomUserDetails.java
+++ b/src/main/java/sws/songpin/global/auth/CustomUserDetails.java
@@ -3,10 +3,12 @@ package sws.songpin.global.auth;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import sws.songpin.domain.member.entity.Member;
 
 import java.util.Collection;
+import java.util.Collections;
 
 @Getter
 @RequiredArgsConstructor
@@ -16,7 +18,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return Collections.singletonList(new SimpleGrantedAuthority(member.getRole().name()));
     }
 
     @Override

--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -22,10 +22,7 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import sws.songpin.global.auth.CustomLogoutHandler;
-import sws.songpin.global.auth.CustomAuthenticationEntryPoint;
-import sws.songpin.global.auth.JwtFilter;
-import sws.songpin.global.auth.JwtUtil;
+import sws.songpin.global.auth.*;
 
 import java.util.Arrays;
 
@@ -37,6 +34,7 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomLogoutHandler logoutHandler;
 
     @Bean
@@ -110,7 +108,10 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/members/{handle}/playlists").permitAll()
                         .requestMatchers(HttpMethod.GET, "/members/{handle}/feed").permitAll()
                         .anyRequest().authenticated())
-                .exceptionHandling(e -> e.authenticationEntryPoint(customAuthenticationEntryPoint))
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                )
         ;
 
         return http.build();

--- a/src/main/java/sws/songpin/global/config/SecurityConfig.java
+++ b/src/main/java/sws/songpin/global/config/SecurityConfig.java
@@ -23,7 +23,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import sws.songpin.global.auth.CustomLogoutHandler;
-import sws.songpin.global.auth.JwtAuthenticationEntryPoint;
+import sws.songpin.global.auth.CustomAuthenticationEntryPoint;
 import sws.songpin.global.auth.JwtFilter;
 import sws.songpin.global.auth.JwtUtil;
 
@@ -36,7 +36,7 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomLogoutHandler logoutHandler;
 
     @Bean
@@ -110,7 +110,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/members/{handle}/playlists").permitAll()
                         .requestMatchers(HttpMethod.GET, "/members/{handle}/feed").permitAll()
                         .anyRequest().authenticated())
-                .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .exceptionHandling(e -> e.authenticationEntryPoint(customAuthenticationEntryPoint))
         ;
 
         return http.build();

--- a/src/main/java/sws/songpin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sws/songpin/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -73,5 +74,18 @@ public class GlobalExceptionHandler {
                 request.getRequestURI()
         );
         return new ResponseEntity<>(errorDto, HttpStatus.BAD_REQUEST);
+    }
+
+    // MVC 계층에서 발생한 AccessDeniedException 처리
+    @ExceptionHandler({AccessDeniedException.class})
+    protected ResponseEntity<ErrorDto> handleAccessDeniedException(AccessDeniedException e, HttpServletRequest request){
+        ErrorDto errorDto = new ErrorDto(
+                LocalDateTime.now().toString(),
+                HttpStatus.FORBIDDEN.value(),
+                "ACCESS_DENIED",
+                "접근 권한이 없습니다.",
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorDto, HttpStatus.FORBIDDEN);
     }
 }


### PR DESCRIPTION
# 구현 기능
  - Authentication 객체에 유저의 권한 정보가 포함되도록 수정
    - 알고보니 지금까지 Authentication 에 유저의 권한 정보가 null 로 담겨있었던 것을 확인하고 수정했습니다... 서버에 AccessDeniedException 관련 로그가 떴던 것도 아마 이것 때문이지 않을까 싶습니다. 
   
  - AccessDeniedException 핸들링 
    - CustomAccessDeniedHandler
    - GlobalExceptionHandler 
      (@MethodSecurity 으로 인해 AccessDeniedException 이 발생할 시 SecurityFilterChain 까지 올라가지 않고 ControllerAdvice 에서 에러를 캐치한다고 하여 GlobalExceptionHandler 에도 메서드를 추가 [참고](https://www.inflearn.com/community/questions/1212885/exceptionhandler%EA%B0%80-accessdeniedhandler-http403handler-%EB%A5%BC-%EB%A8%B9%EC%96%B4%EB%B2%84%EB%A6%AC%EB%8A%94-%ED%98%84%EC%83%81))



# 구현 상태 (선택)
- CustomAccessDeniedHandler 에서 캐치할 경우 응답

    ```
    {
      "error": "Forbidden",
      "message": "Access Denied",
      "path": "/members/22",
      "status": 403,
      "timestamp": "2024-08-20T22:38:35.630+00:00"
    }
    ```
- GlobalExceptionHandler 에서 캐치할 경우 응답  

    ```
    {
      "timestamp": "2024-08-21T07:38:47.770271100",
      "status": 403,
      "errorCode": "ACCESS_DENIED",
      "message": "접근 권한이 없습니다.",
      "path": "/roleTest"
    }
    ```

# Resolve
  - #182